### PR TITLE
Remove dates on persone_famiglie and delete famiglie_posizioni

### DIFF
--- a/.github/workflows/run-linter.yml
+++ b/.github/workflows/run-linter.yml
@@ -1,4 +1,4 @@
-name: PHP linting (Pint)
+name: run_linter
 
 on:
   push:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: run_tests
 
 on: push
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: run_tests
 
-on: push
+on: [push, pull_request]
 
 jobs:
   test:

--- a/database/migrations/db_nomadelfia/2022_12_04_004646_create_view_popolazione_attuale.up.sql
+++ b/database/migrations/db_nomadelfia/2022_12_04_004646_create_view_popolazione_attuale.up.sql
@@ -26,12 +26,12 @@ CREATE VIEW IF NOT EXISTS v_popolazione_attuale AS
     GROUP by gruppi_persone.persona_id
     ORDER BY gruppi_persone.data_entrata_gruppo DESC
 ), famiglia AS (
-    SELECT famiglie_persone.persona_id, max(famiglie_persone.data_entrata) as famiglia_inizio, famiglie.nome_famiglia as famiglia, famiglie_persone.posizione_famiglia
+    SELECT famiglie_persone.persona_id, famiglie.data_creazione as famiglia_inizio, famiglie.nome_famiglia as famiglia, famiglie_persone.posizione_famiglia
     FROM famiglie_persone
     JOIN famiglie ON famiglie.id = famiglie_persone.famiglia_id
     WHERE famiglie_persone.persona_id IN (SELECT id from pop)
     GROUP BY famiglie_persone.persona_id
-    ORDER BY famiglie_persone.data_entrata DESC
+    ORDER BY famiglie.data_creazione DESC
 ), azienda AS (
     SELECT aziende_persone.persona_id, max(aziende_persone.data_inizio_azienda) as azienda_inizio, aziende.nome_azienda as azienda
     FROM aziende_persone

--- a/database/migrations/db_nomadelfia/2023_11_09_171412_delete_family_dates.down.sql
+++ b/database/migrations/db_nomadelfia/2023_11_09_171412_delete_family_dates.down.sql
@@ -1,0 +1,1 @@
+-- Reverse the migrations

--- a/database/migrations/db_nomadelfia/2023_11_09_171412_delete_family_dates.php
+++ b/database/migrations/db_nomadelfia/2023_11_09_171412_delete_family_dates.php
@@ -1,0 +1,8 @@
+<?php
+
+use SqlMigrations\SqlMigration;
+
+class DeleteFamilyDates extends SqlMigration
+{
+    public $connection = 'db_nomadelfia';
+}

--- a/database/migrations/db_nomadelfia/2023_11_09_171412_delete_family_dates.up.sql
+++ b/database/migrations/db_nomadelfia/2023_11_09_171412_delete_family_dates.up.sql
@@ -1,0 +1,7 @@
+-- Run the migrations
+
+ALTER TABLE `famiglie_persone` CHANGE `data_entrata` `deleteme_data_entrata` DATE NULL DEFAULT NULL;
+
+ALTER TABLE `famiglie_persone` CHANGE `data_uscita` `deleteme_data_uscita` DATE NULL DEFAULT NULL;
+
+DROP TABLE `famiglie_posizioni`;

--- a/database/seeders/NomadelfiaTableSeeder.php
+++ b/database/seeders/NomadelfiaTableSeeder.php
@@ -9,6 +9,7 @@ use Domain\Nomadelfia\GruppoFamiliare\Models\GruppoFamiliare;
 use Domain\Nomadelfia\Persona\Models\Persona;
 use Domain\Nomadelfia\PopolazioneNomadelfia\Actions\EntrataDallaNascitaAction;
 use Domain\Nomadelfia\PopolazioneNomadelfia\Actions\EntrataMaggiorenneConFamigliaAction;
+use Domain\Nomadelfia\PopolazioneNomadelfia\Actions\EntrataMaggiorenneSingleAction;
 use Domain\Nomadelfia\PopolazioneNomadelfia\Actions\EntrataMinorenneAccoltoAction;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
@@ -27,6 +28,7 @@ class NomadelfiaTableSeeder extends Seeder
             ->createIncarichi();
 
         $this->insertFamigliaInPopolazione();
+        $this->insertSingleInPopolazione();
 
     }
 
@@ -391,7 +393,7 @@ class NomadelfiaTableSeeder extends Seeder
         $act->execute($capoFam, $now, $gruppo);
         $act = app(EntrataMaggiorenneConFamigliaAction::class);
         $act->execute($moglie, $now, $gruppo);
-        $famiglia->assegnaCapoFamiglia($capoFam, $now);
+        $famiglia->assegnaCapoFamiglia($capoFam);
         $famiglia->assegnaMoglie($moglie, $now);
         app(EntrataDallaNascitaAction::class)->execute(Persona::factory()->diEta(3)->femmina()->create(), $famiglia);
         app(EntrataDallaNascitaAction::class)->execute(Persona::factory()->diEta(4)->maschio()->create(), $famiglia);
@@ -404,6 +406,17 @@ class NomadelfiaTableSeeder extends Seeder
         app(EntrataMinorenneAccoltoAction::class)->execute(Persona::factory()->diEta(9)->maschio()->create(), Carbon::now()->addYears(5)->toDatestring(), $famiglia);
         app(EntrataDallaNascitaAction::class)->execute(Persona::factory()->diEta(10)->femmina()->create(), $famiglia);
 
+        return $this;
+    }
+
+    protected function insertSingleInPopolazione(): self
+    {
+        $act = app(EntrataMaggiorenneSingleAction::class);
+        $act->execute(
+            Persona::factory()->maggiorenne()->femmina()->create(),
+            Carbon::now()->toDatestring(),
+            GruppoFamiliare::all()->random()
+        );
         return $this;
     }
 }

--- a/database/seeders/NomadelfiaTableSeeder.php
+++ b/database/seeders/NomadelfiaTableSeeder.php
@@ -417,6 +417,7 @@ class NomadelfiaTableSeeder extends Seeder
             Carbon::now()->toDatestring(),
             GruppoFamiliare::all()->random()
         );
+
         return $this;
     }
 }

--- a/resources/views/nomadelfia/famiglie/create.blade.php
+++ b/resources/views/nomadelfia/famiglie/create.blade.php
@@ -5,46 +5,32 @@
 @include('partials.header', ['title' => 'Creazione nuova Famiglia'])
 
 <div class="row">
-  <div class="col-md-6 offset-md-3">
-  <h4>Dati Famiglia</h4>
-  <form method="POST" action="{{route('nomadelfia.famiglie.create.confirm')}}">
-    {{ csrf_field() }}
-    <div class="form-group row">
-      <label for="fornome" class="col-md-6 col-form-label">Nome famiglia:</label>
-      <div class="col-md-6">
-        <input class="form-control" id="fornome" name="nome"  value="{{ old('nome') }}" placeholder="Nome famiglia">
-      </div>
-    </div>
-    <div class="form-group row">
-      <label for="fordatainizio" class="col-md-6 col-form-label">Data creazione famiglia:</label>
-      <div class="col-md-6">
-         <date-picker :bootstrap-styling="true"  value="{{ old('data_inizio') }}" format="yyyy-MM-dd" name="data_inizio"></date-picker>
-      </div>
-    </div>
-  <!-- <h4>Componenti della famiglia</h4>
-  <div class="form-group row">
-      <label for="fornome" class="col-md-4 col-form-label">Persona:</label>
-      <div class="col-md-4">
-        <autocomplete placeholder="Inserisci nominativo..." name="persona_id" url="{{route('api.nomadeflia.persone.search')}}"></autocomplete>
-      </div>
-      <div class="col-md-4">
-        <select class="form-control" name="posizione">
-         <option value="" selected>---scegli posizione---</option>
-          @foreach (Domain\Nomadelfia\Famiglia\models\Famiglia::getEnum('Posizione') as $posizione)
-              <option value="{{ $posizione }}">{{ $posizione }}</option>
-            @endforeach
-        </select>
-      </div>
-    </div> -->
+    <div class="col-md-6 offset-md-3">
+        <h4>Dati Famiglia</h4>
+        <form method="POST" action="{{route('nomadelfia.famiglie.create.confirm')}}">
+            {{ csrf_field() }}
+            <div class="form-group row">
+                <label for="fornome" class="col-md-6 col-form-label">Nome famiglia:</label>
+                <div class="col-md-6">
+                    <input class="form-control" id="fornome" name="nome" value="{{ old('nome') }}"
+                           placeholder="Nome famiglia">
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="fordatainizio" class="col-md-6 col-form-label">Data creazione famiglia:</label>
+                <div class="col-md-6">
+                    <date-picker :bootstrap-styling="true" value="{{ old('data_inizio') }}" format="yyyy-MM-dd"
+                                 name="data_inizio"></date-picker>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-auto">
+                    <!-- <button class="btn btn-warning" name="_addanother" value="true" type="submit">Salva e aggiungi un'altra </button> -->
+                    <button class="btn btn-success" name="_addonly" value="true" type="submit">Salva</button>
+                </div>
+            </div>
 
-    <div class="row">
-      <div class="col-auto">
-        <!-- <button class="btn btn-warning" name="_addanother" value="true" type="submit">Salva e aggiungi un'altra </button> -->
-        <button class="btn btn-success" name="_addonly" value="true" type="submit">Salva</button> 
-      </div>
+        </form>
     </div>
-    
-  </form>
-  </div>
 </div>
 @endsection

--- a/resources/views/nomadelfia/templates/aggiornaComponente.blade.php
+++ b/resources/views/nomadelfia/templates/aggiornaComponente.blade.php
@@ -1,70 +1,59 @@
-
- <my-modal modal-title="Aggiorna componente" button-title="Modifica" button-style="btn-warning my-2">
-        <template slot="modal-body-slot">
-        <form class="form" method="POST" id="formComponenteAggiorna{{$componente->persona_id}}" action="{{ route('nomadelfia.famiglie.componente.aggiorna', ['id' =>$famiglia->id]) }}" >      
+<my-modal modal-title="Aggiorna componente" button-title="Modifica" button-style="btn-warning my-2">
+    <template slot="modal-body-slot">
+        <form class="form" method="POST" id="formComponenteAggiorna{{$componente->persona_id}}"
+              action="{{ route('nomadelfia.famiglie.componente.aggiorna', ['id' =>$famiglia->id]) }}">
             {{ csrf_field() }}
             <div class="form-group row">
-            <label for="example-text-input" class="col-4 col-form-label">Persona</label>
-                <div class="col-8" >
+                <label for="example-text-input" class="col-4 col-form-label">Persona</label>
+                <div class="col-8">
 
                     <input class="form-control" type="text" name="persona_id" value="{{$componente->id}}" hidden>
                     {{$componente->nominativo}}
                 </div>
             </div>
             <div class="form-group row">
-            <label for="example-text-input" class="col-4 col-form-label">Posizione Famiglia</label>
+                <label for="example-text-input" class="col-4 col-form-label">Posizione Famiglia</label>
                 <div class="col-8">
-                <select class="form-control" name="posizione">
-                <option value={{ $componente->posizione_famiglia }} selected>---scegli posizione---</option>
-                    @foreach (Domain\Nomadelfia\Famiglia\models\Famiglia::getEnum('Posizione') as $posizione)
+                    <select class="form-control" name="posizione">
+                        <option value={{ $componente->posizione_famiglia }} selected>---scegli posizione---</option>
+                        @foreach (Domain\Nomadelfia\Famiglia\models\Famiglia::getEnum('Posizione') as $posizione)
                         @if($posizione == $componente->posizione_famiglia)
                         <option value="{{ $posizione }}" selected>{{ $posizione }}</option>
                         @else
                         <option value="{{ $posizione }}">{{ $posizione }}</option>
                         @endif
-                    @endforeach
-                </select>
+                        @endforeach
+                    </select>
                 </div>
             </div>
             <div class="form-group row">
-            <label for="example-text-input" class="col-4 col-form-label">Data entrata nella famiglia: 
-            </label>
+                <label for="example-text-input" class="col-4 col-form-label">Stato:</label>
                 <div class="col-8">
-                        <date-picker :bootstrap-styling="true" value="{{$componente->data_entrata}}" format="yyyy-MM-dd" name="data_entrata"></date-picker>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="stato" id="stato1" value="1" {{
+                               $componente->stato === '1' ? 'checked' : '' }}>
+                        <label class="form-check-label" for="stato1">
+                            Includi nel nucleo familiare
+                        </label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="stato" id="stato2" value="0" {{
+                               $componente->stato === '0' ? 'checked' : '' }}>
+                        <label class="form-check-label" for="stato2">
+                            Non includere nel nucleo familiare
+                        </label>
+                    </div>
                 </div>
             </div>
             <div class="form-group row">
-            <label for="example-text-input" class="col-4 col-form-label">Data uscita dalla famiglia:</label>
+                <label for="example-text-input" class="col-4 col-form-label">Note:</label>
                 <div class="col-8">
-                <date-picker :bootstrap-styling="true" value="{{$componente->data_uscita}}" format="yyyy-MM-dd" name="data_uscita"></date-picker>
-                </div>
-            </div>
-            <div class="form-group row">
-            <label for="example-text-input" class="col-4 col-form-label">Stato:</label>
-                <div class="col-8">
-                <div class="form-check">
-                <input class="form-check-input" type="radio" name="stato" id="stato1" value="1" {{ $componente->stato === '1' ? 'checked' : '' }}>
-                <label class="form-check-label" for="stato1">
-                    Includi nel nucleo familiare
-                </label>
-                </div>
-                <div class="form-check">
-                <input class="form-check-input" type="radio" name="stato" id="stato2" value="0" {{ $componente->stato === '0' ? 'checked' : '' }}>
-                <label class="form-check-label" for="stato2">
-                    Non includere nel nucleo familiare
-                </label>
-                </div>
-                </div>
-            </div>
-            <div class="form-group row">
-            <label for="example-text-input" class="col-4 col-form-label">Note:</label>
-                <div class="col-8">
-                <textarea class="form-control" name="note" id="exampleFormControlTextarea1" rows="3"></textarea>
+                    <textarea class="form-control" name="note" id="exampleFormControlTextarea1" rows="3"></textarea>
                 </div>
             </div>
         </form>
-        </template> 
-        <template slot="modal-button">
-            <button class="btn btn-danger" form="formComponenteAggiorna{{$componente->persona_id}}">Salva</button>
-        </template>
-    </my-modal>  
+    </template>
+    <template slot="modal-button">
+        <button class="btn btn-danger" form="formComponenteAggiorna{{$componente->persona_id}}">Salva</button>
+    </template>
+</my-modal>

--- a/resources/views/nomadelfia/templates/aggiungiComponente.blade.php
+++ b/resources/views/nomadelfia/templates/aggiungiComponente.blade.php
@@ -1,58 +1,54 @@
-<my-modal modal-title="Aggiungi componente alla famiglia" button-title="Aggiungi Componente" button-style="btn-primary my-2">
-  <template slot="modal-body-slot">
-    <form class="form" method="POST" id="formComponente" action="{{ route('nomadelfia.famiglie.componente.assegna', ['id' =>$famiglia->id]) }}" >      
-      {{ csrf_field() }}
-      <div class="form-group row">
-        <label for="example-text-input" class="col-4 col-form-label">Persona</label>
-          <div class="col-8">
-            <autocomplete placeholder="Inserisci nominativo..." name="persona_id" url="{{route('api.nomadeflia.popolazione.search')}}"></autocomplete>
-          </div>
-      </div>
-      <div class="form-group row">
-        <label for="example-text-input" class="col-4 col-form-label">Posizione Famiglia</label>
-          <div class="col-8">
-            <select class="form-control" name="posizione">
-            <option value="" selected>---scegli posizione---</option>
-              @foreach (Domain\Nomadelfia\Famiglia\models\Famiglia::getEnum('Posizione') as $posizione)
-                  <option value="{{ $posizione }}">{{ $posizione }}</option>
-                @endforeach
-              </select>
-          </div>
-      </div>
-      <div class="form-group row">
-        <label for="example-text-input" class="col-4 col-form-label">Data entrata nella famiglia:</label>
-          <div class="col-8">
-            <date-picker :bootstrap-styling="true" value="{{ old('data_entrata') }}" format="yyyy-MM-dd" name="data_entrata"></date-picker>
-            <small id="emailHelp" class="form-text text-muted">Lasciare vuoto se concide con la data di nascita/matrimonio del nuovo componente.</small>
-          </div>
-      </div>
-      <div class="form-group row">
-        <label for="example-text-input" class="col-4 col-form-label">Stato:</label>
-          <div class="col-8">
-          <div class="form-check">
-            <input class="form-check-input" type="radio" name="stato" id="stato1" value="1" checked>
-            <label class="form-check-label" for="stato1">
-              Includi nel nucleo familiare
-            </label>
-          </div>
-          <div class="form-check">
-            <input class="form-check-input" type="radio" name="stato" id="stato2" value="0">
-            <label class="form-check-label" for="stato2">
-              Non includere nel nucleo familiare
-            </label>
-          </div>
-          </div>
-      </div>
-      <div class="form-group row">
-        <label for="example-text-input" class="col-4 col-form-label">Note:</label>
-          <div class="col-8">
-            <!-- <input type="date" class="form-control" name="note" placeholder="Data entrata nella famiglia" > -->
-            <textarea class="form-control" name="note" id="exampleFormControlTextarea1" rows="3"></textarea>
-          </div>
-      </div>
-    </form>
-  </template> 
-  <template slot="modal-button">
+<my-modal modal-title="Aggiungi componente alla famiglia" button-title="Aggiungi Componente"
+          button-style="btn-primary my-2">
+    <template slot="modal-body-slot">
+        <form class="form" method="POST" id="formComponente"
+              action="{{ route('nomadelfia.famiglie.componente.assegna', ['id' =>$famiglia->id]) }}">
+            {{ csrf_field() }}
+            <div class="form-group row">
+                <label for="example-text-input" class="col-4 col-form-label">Persona</label>
+                <div class="col-8">
+                    <autocomplete placeholder="Inserisci nominativo..." name="persona_id"
+                                  url="{{route('api.nomadeflia.popolazione.search')}}"></autocomplete>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="example-text-input" class="col-4 col-form-label">Posizione Famiglia</label>
+                <div class="col-8">
+                    <select class="form-control" name="posizione">
+                        <option value="" selected>---scegli posizione---</option>
+                        @foreach (Domain\Nomadelfia\Famiglia\models\Famiglia::getEnum('Posizione') as $posizione)
+                        <option value="{{ $posizione }}">{{ $posizione }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="example-text-input" class="col-4 col-form-label">Stato:</label>
+                <div class="col-8">
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="stato" id="stato1" value="1" checked>
+                        <label class="form-check-label" for="stato1">
+                            Includi nel nucleo familiare
+                        </label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="stato" id="stato2" value="0">
+                        <label class="form-check-label" for="stato2">
+                            Non includere nel nucleo familiare
+                        </label>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="example-text-input" class="col-4 col-form-label">Note:</label>
+                <div class="col-8">
+                    <!-- <input type="date" class="form-control" name="note" placeholder="Data entrata nella famiglia" > -->
+                    <textarea class="form-control" name="note" id="exampleFormControlTextarea1" rows="3"></textarea>
+                </div>
+            </div>
+        </form>
+    </template>
+    <template slot="modal-button">
         <button class="btn btn-danger" form="formComponente">Salva</button>
-  </template>
+    </template>
 </my-modal> 

--- a/src/App/Sin/Nomadelfia/Famiglia/Controllers/FamiglieController.php
+++ b/src/App/Sin/Nomadelfia/Famiglia/Controllers/FamiglieController.php
@@ -146,31 +146,29 @@ class FamiglieController extends CoreBaseController
             'persona_id' => 'required',
             'posizione' => 'required',
             'stato' => 'required',
-            'data_entrata' => 'date',
         ], [
             'persona_id.required' => 'La persona è obbligatoria.',
             'stato.required' => 'Lo stato della persona è obbligatoria.',
             'posizione.required' => 'La posizione nella famiglia è obbligatoria.',
-            'data_entrata.date' => 'La data del cambio di gruppo non è una data corretta.',
         ]);
         $famiglia = Famiglia::findorfail($id);
         $persona = Persona::findorfail($request->persona_id);
 
         switch ($request->posizione) {
             case 'CAPO FAMIGLIA':
-                $famiglia->assegnaCapoFamiglia($persona, $request->data_entrata);
+                $famiglia->assegnaCapoFamiglia($persona);
                 break;
             case 'MOGLIE':
-                $famiglia->assegnaMoglie($persona, $request->data_entrata);
+                $famiglia->assegnaMoglie($persona);
                 break;
             case 'FIGLIO NATO':
                 $famiglia->assegnaFiglioNato($persona);
                 break;
             case 'FIGLIO ACCOLTO':
-                $famiglia->assegnaFiglioAccolto($persona, $request->data_entrata);
+                $famiglia->assegnaFiglioAccolto($persona);
                 break;
             case 'SINGLE':
-                $famiglia->assegnaSingle($persona, $request->data_entrata);
+                $famiglia->assegnaSingle($persona);
                 break;
             default:
                 return redirect(route('nomadelfia.famiglia.dettaglio',
@@ -188,23 +186,16 @@ class FamiglieController extends CoreBaseController
             'persona_id' => 'required',
             'posizione' => 'required',
             'stato' => 'required',
-            'data_entrata' => 'date',
-            'data_uscita' => 'date',
         ], [
             'persona_id.required' => 'La persona è obbligatoria.',
             'stato.required' => 'Lo stato della persona è obbligatoria.',
             'posizione.required' => 'La posizione nella famiglia è obbligatoria.',
-            'data_entrata.date' => 'La data di entrana nella famiglia non è una data corretta.',
-            'data_uscita.date' => 'La data di uscita dalla famiglia non è una data corretta.',
-
         ]);
         $famiglia = Famiglia::findorfail($id);
         try {
             $famiglia->componenti()->updateExistingPivot($request->persona_id, [
                 'stato' => $request->stato,
                 'posizione_famiglia' => $request->posizione,
-                'data_entrata' => $request->data_entrata,
-                'data_uscita' => $request->data_uscita,
                 'note' => $request->note,
             ]);
 

--- a/src/App/Sin/Nomadelfia/PopolazioneNomadelfia/Controllers/AggiornamentoAnagrafeController.php
+++ b/src/App/Sin/Nomadelfia/PopolazioneNomadelfia/Controllers/AggiornamentoAnagrafeController.php
@@ -9,7 +9,7 @@ class AggiornamentoAnagrafeController extends CoreBaseController
 {
     public function index()
     {
-        $activity = AggiornamentoAnagrafe::orderBy('created_at', 'DESC')->take(20)->get();
+        $activity = AggiornamentoAnagrafe::orderBy('created_at', 'DESC')->take(50)->get();
 
         return view('nomadelfia.aggiornamento-anagrafe.index', compact('activity'));
     }

--- a/src/App/Sin/Scuola/Models/ClasseTipo.php
+++ b/src/App/Sin/Scuola/Models/ClasseTipo.php
@@ -236,11 +236,11 @@ class ClasseTipo extends Model
             //                        ['stato' => '0', 'data_fine' => ($attuale_data_fine ? $attuale_data_fine : $data_inizio)]);
             //                }
             $this->alunni()->attach($persona->id, ['data_inizio' => $data_inizio]);
-            //                DB::connection('db_nomadelfia')->commit();
-            //            } catch (\Exception $e) {
-            //                DB::connection('db_nomadelfia')->rollback();
-            //                throw $e;
-            //            }
+        //                DB::connection('db_nomadelfia')->commit();
+        //            } catch (\Exception $e) {
+        //                DB::connection('db_nomadelfia')->rollback();
+        //                throw $e;
+        //            }
         } else {
             throw new Exception('Bad Argument. Persona must be an id or a model.');
         }

--- a/src/Domain/Nomadelfia/Famiglia/Models/Famiglia.php
+++ b/src/Domain/Nomadelfia/Famiglia/Models/Famiglia.php
@@ -277,6 +277,7 @@ class Famiglia extends Model
             if ($persona->isMaggiorenne() != true) {
                 throw CouldNotAssignCapoFamiglia::beacuseIsMinorenne($this, $persona);
             }
+
             return $this->assegnaComponente($persona, $this->getCapoFamigliaEnum());
         } else {
             throw new InvalidArgumentException("Identiticativo `{$persona}` della persona non valido.");
@@ -365,7 +366,7 @@ class Famiglia extends Model
 
     public function assegnaComponente($persona, string $posizione, string $stato = '1', $note = null)
     {
-        if (!in_array($posizione, $this->enumPosizione)) {
+        if (! in_array($posizione, $this->enumPosizione)) {
             throw new InvalidArgumentException("La posizione `{$posizione}` è invalida");
         }
 
@@ -529,8 +530,7 @@ class Famiglia extends Model
         $dataUscitaGruppoFamiliareAttuale,
         $gruppo_nuovo_id,
         $data_entrata = null
-    )
-    {
+    ) {
         $famiglia_id = $this->id;
 
         return DB::transaction(function () use (
@@ -605,7 +605,7 @@ class Famiglia extends Model
               WHERE (g.posizione_famiglia = 'SINGLE' AND g.count>1) OR   (g.posizione_famiglia = 'CAPO FAMIGLIA' AND g.count>1) OR (g.posizione_famiglia = 'MOGLIE' AND g.count>1)"
             )
         );
-        $result->push((object)['descrizione' => 'Famiglie non valide', 'results' => $famiglie]);
+        $result->push((object) ['descrizione' => 'Famiglie non valide', 'results' => $famiglie]);
 
         $famiglieSenzaComponenti = DB::connection('db_nomadelfia')->select(
             DB::raw(
@@ -620,7 +620,7 @@ class Famiglia extends Model
             )
         );
 
-        $result->push((object)[
+        $result->push((object) [
             'descrizione' => 'Famiglie senza componenti o con nessun componente attivo',
             'results' => $famiglieSenzaComponenti,
         ]);
@@ -636,7 +636,7 @@ class Famiglia extends Model
       )
         ")
         );
-        $result->push((object)['descrizione' => 'Famiglie senza un CAPO FAMIGLIA', 'results' => $famiglieSenzaCapo]);
+        $result->push((object) ['descrizione' => 'Famiglie senza un CAPO FAMIGLIA', 'results' => $famiglieSenzaCapo]);
 
         $famiglieConPiuGruppi = DB::connection('db_nomadelfia')->select(
             DB::raw("SELECT *
@@ -651,7 +651,7 @@ class Famiglia extends Model
                 HAVING count(*) > 1
               )")
         );
-        $result->push((object)[
+        $result->push((object) [
             'descrizione' => 'Famiglie assegnate in più di un grupo familiare',
             'results' => $famiglieConPiuGruppi,
         ]);

--- a/src/Domain/Nomadelfia/Persona/Models/Persona.php
+++ b/src/Domain/Nomadelfia/Persona/Models/Persona.php
@@ -122,7 +122,7 @@ class Persona extends Model
     public function proposeNumeroElenco()
     {
         if ($this->numero_elenco) {
-            throw new Exception('La persona ' . $this->nominativo . ' ha già un numero di elenco ' . $this->numero_elenco);
+            throw new Exception('La persona '.$this->nominativo.' ha già un numero di elenco '.$this->numero_elenco);
         }
         $firstLetter = Str::substr($this->cognome, 0, 1);
         $res = $this->select(DB::raw('persone.*, left(numero_elenco,1) as  lettera, CAST(right(numero_elenco, length(numero_elenco)-1) as integer)  as numero'))
@@ -131,12 +131,12 @@ class Persona extends Model
             ->orderBy('numero', 'DESC')
             ->first();
         if ($res) {
-            $new = (int)$res->numero + 1;
+            $new = (int) $res->numero + 1;
 
-            return $res->lettera . $new;
+            return $res->lettera.$new;
         }
 
-        return $firstLetter . '1';
+        return $firstLetter.'1';
 
     }
 
@@ -189,8 +189,7 @@ class Persona extends Model
         string $orderBy = 'nominativo',
         $travel_to_year = null,
         $withInYear = false
-    )
-    {
+    ) {
         $date = ($travel_to_year == null ? Carbon::now() : Carbon::now()->setYear($travel_to_year));
         $end = $date->copy()->subYears($frometa);
         if ($withInYear) {
@@ -315,8 +314,7 @@ class Persona extends Model
         $dataout_current,
         $gruppo_id_new,
         $datain_new
-    )
-    {
+    ) {
         $persona_id = $this->id;
 
         DB::transaction(function () use (
@@ -394,7 +392,7 @@ class Persona extends Model
         }
         if (strcasecmp($mansione, 'LAVORATORE') == 0 or strcasecmp($mansione, 'RESPONSABILE AZIENDA') == 0) {
             if ($azienda instanceof Azienda) {
-                if (!$azienda->isAzienda()) {
+                if (! $azienda->isAzienda()) {
                     throw CouldNotAssignAzienda::isNotValidAzienda($azienda);
                 }
                 if ($this->aziendeAttuali->contains($azienda->id)) { // la persona è stata già asseganta all'azienda
@@ -460,7 +458,7 @@ class Persona extends Model
         if (is_string($incarico)) {
             $incarico = Incarico::findOrFail($incarico);
         }
-        if (!$incarico instanceof Incarico) {
+        if (! $incarico instanceof Incarico) {
             throw new Exception('Bad Argument. Incarico must be the id or a model.');
         }
         if ($this->incarichiAttuali()->where('id', $incarico->id)->exists()) { // la persona è stata già l'incarico
@@ -712,7 +710,7 @@ class Persona extends Model
         }
         $attuale = $this->famigliaAttuale();
         try {
-            if (!$attuale) {
+            if (! $attuale) {
                 $this->famiglie()->attach($famiglia->id,
                     ['stato' => '1', 'posizione_famiglia' => $posizione]);
             } else {
@@ -886,8 +884,7 @@ class Persona extends Model
 
     public function assegnaNomadelfoEffettivo(
         Carbon\Carbon $data_inizio
-    )
-    {
+    ) {
         // TODO: check that the posizione attuale è postulante
         //        $attuale = this->posizioneAttuale();
         //        if $attuale && !$attuale->isPostulante){
@@ -901,8 +898,7 @@ class Persona extends Model
         $posizione,
         string $data_inizio,
         string $attuale_data_fine = null
-    )
-    {
+    ) {
         if (is_string($posizione) || is_int($posizione)) {
             $posizione = Posizione::findOrFail($posizione);
         }
@@ -929,8 +925,7 @@ class Persona extends Model
         $posizione_id,
         $currentDatain,
         $newDataIn
-    )
-    {
+    ) {
         $res = DB::connection('db_nomadelfia')->update(
             DB::raw('UPDATE persone_posizioni
                SET  data_inizio = :new
@@ -945,8 +940,7 @@ class Persona extends Model
         $posizione_id,
         $datain,
         $datafine
-    )
-    {
+    ) {
         $res = DB::connection('db_nomadelfia')->update(
             DB::raw("UPDATE persone_posizioni
                SET stato = '0', data_fine = :dataout
@@ -1002,18 +996,17 @@ class Persona extends Model
     /**
      * Sposta una persona e la sua famiglia dal gruppo familiare attuale in un nuovo gruppo familiare.
      *
-     * @param int|null $gruppoFamiliareAttuale
-     * @param date $dataUscitaGruppoFamiliareAttuale
-     * @param int $gruppoFamiliareNuovo
-     * @param date $dataEntrataGruppo
+     * @param  int|null  $gruppoFamiliareAttuale
+     * @param  date  $dataUscitaGruppoFamiliareAttuale
+     * @param  int  $gruppoFamiliareNuovo
+     * @param  date  $dataEntrataGruppo
      */
     public function cambiaGruppoFamiliare(
         $gruppoFamiliareAttuale,
         $dataUscitaGruppoFamiliareAttuale,
         $gruppoFamiliareNuovo,
         $dataEntrataGruppo
-    )
-    {
+    ) {
         if ($this->isCapoFamiglia() or $this->isSingle()) {
             $this->famigliaAttuale()->assegnaFamigliaANuovoGruppoFamiliare($gruppoFamiliareAttuale,
                 $dataUscitaGruppoFamiliareAttuale, $gruppoFamiliareNuovo, $dataEntrataGruppo);
@@ -1025,8 +1018,7 @@ class Persona extends Model
         $dataUscitaGruppoFamiliareAttuale,
         $gruppoFamiliareNuovo,
         $dataEntrataGruppo = null
-    )
-    {
+    ) {
         try {
             $this->gruppifamiliari()->updateExistingPivot($gruppoFamiliareAttuale,
                 ['stato' => '0', 'data_uscita_gruppo' => $dataUscitaGruppoFamiliareAttuale]);

--- a/src/Domain/Nomadelfia/Persona/Models/Persona.php
+++ b/src/Domain/Nomadelfia/Persona/Models/Persona.php
@@ -122,7 +122,7 @@ class Persona extends Model
     public function proposeNumeroElenco()
     {
         if ($this->numero_elenco) {
-            throw new Exception('La persona '.$this->nominativo.' ha già un numero di elenco '.$this->numero_elenco);
+            throw new Exception('La persona ' . $this->nominativo . ' ha già un numero di elenco ' . $this->numero_elenco);
         }
         $firstLetter = Str::substr($this->cognome, 0, 1);
         $res = $this->select(DB::raw('persone.*, left(numero_elenco,1) as  lettera, CAST(right(numero_elenco, length(numero_elenco)-1) as integer)  as numero'))
@@ -131,12 +131,12 @@ class Persona extends Model
             ->orderBy('numero', 'DESC')
             ->first();
         if ($res) {
-            $new = (int) $res->numero + 1;
+            $new = (int)$res->numero + 1;
 
-            return $res->lettera.$new;
+            return $res->lettera . $new;
         }
 
-        return $firstLetter.'1';
+        return $firstLetter . '1';
 
     }
 
@@ -189,7 +189,8 @@ class Persona extends Model
         string $orderBy = 'nominativo',
         $travel_to_year = null,
         $withInYear = false
-    ) {
+    )
+    {
         $date = ($travel_to_year == null ? Carbon::now() : Carbon::now()->setYear($travel_to_year));
         $end = $date->copy()->subYears($frometa);
         if ($withInYear) {
@@ -314,7 +315,8 @@ class Persona extends Model
         $dataout_current,
         $gruppo_id_new,
         $datain_new
-    ) {
+    )
+    {
         $persona_id = $this->id;
 
         DB::transaction(function () use (
@@ -392,7 +394,7 @@ class Persona extends Model
         }
         if (strcasecmp($mansione, 'LAVORATORE') == 0 or strcasecmp($mansione, 'RESPONSABILE AZIENDA') == 0) {
             if ($azienda instanceof Azienda) {
-                if (! $azienda->isAzienda()) {
+                if (!$azienda->isAzienda()) {
                     throw CouldNotAssignAzienda::isNotValidAzienda($azienda);
                 }
                 if ($this->aziendeAttuali->contains($azienda->id)) { // la persona è stata già asseganta all'azienda
@@ -458,7 +460,7 @@ class Persona extends Model
         if (is_string($incarico)) {
             $incarico = Incarico::findOrFail($incarico);
         }
-        if (! $incarico instanceof Incarico) {
+        if (!$incarico instanceof Incarico) {
             throw new Exception('Bad Argument. Incarico must be the id or a model.');
         }
         if ($this->incarichiAttuali()->where('id', $incarico->id)->exists()) { // la persona è stata già l'incarico
@@ -577,8 +579,8 @@ class Persona extends Model
 
             // aggiorna la data di uscita dalla famiglia con la data di decesso
             $conn->insert(
-                "UPDATE famiglie_persone SET data_uscita = ?, stato = '0' WHERE persona_id = ? AND stato = '1'",
-                [$data_decesso, $this->id]
+                "UPDATE famiglie_persone SET stato = '0' WHERE persona_id = ? AND stato = '1'",
+                [$this->id]
             );
 
             DB::connection('db_nomadelfia')->commit();
@@ -658,7 +660,7 @@ class Persona extends Model
     {
         $famiglia = $this->famiglie()
             ->wherePivot('stato', '1')
-            ->withPivot('posizione_famiglia', 'data_entrata', 'data_uscita')
+            ->withPivot('posizione_famiglia')
             ->get();
         if ($famiglia->count() == 1) {
             return $famiglia[0];
@@ -673,21 +675,19 @@ class Persona extends Model
     {
         return $this->famiglie()
             ->wherePivot('stato', '0')
-            ->withPivot('posizione_famiglia', 'data_entrata', 'data_uscita');
+            ->withPivot('posizione_famiglia');
     }
 
     // Crea una famiglia e aggiunge la persona come componente
-    // Se la data_entrata è null (default) viene settata uguale alla data di creazione della famiglia
-    public function createAndAssignFamiglia($persona_id, $posizione, $nome, $data_creazione, $data_entrata = null)
+    public function createAndAssignFamiglia($persona_id, $posizione, $nome, $data_creazione)
     {
         try {
-            DB::transaction(function () use (&$persona_id, &$posizione, &$nome, &$data_creazione, &$data_entrata) {
+            DB::transaction(function () use (&$persona_id, &$posizione, &$nome, &$data_creazione) {
                 $famiglia = Famiglia::create(['nome_famiglia' => $nome, 'data_creazione' => $data_creazione]);
 
                 $famiglia->componenti()->attach($persona_id, [
                     'stato' => '1',
                     'posizione_famiglia' => $posizione,
-                    'data_entrata' => ($data_entrata ? $data_entrata : $data_creazione),
                 ]);
             });
 
@@ -704,7 +704,7 @@ class Persona extends Model
      * @param Famiglia
      * @return $this
      */
-    public function spostaNellaFamiglia($famiglia, $data_entrata, $posizione, $data_uscita = null)
+    public function spostaNellaFamiglia($famiglia, $posizione)
     {
         if ($famiglia->single()) {
             throw SpostaNellaFamigliaError::create($this->nominativo, $famiglia->nome_famiglia,
@@ -712,26 +712,24 @@ class Persona extends Model
         }
         $attuale = $this->famigliaAttuale();
         try {
-            if (! $attuale) {
+            if (!$attuale) {
                 $this->famiglie()->attach($famiglia->id,
-                    ['stato' => '1', 'posizione_famiglia' => $posizione, 'data_entrata' => $data_entrata]);
+                    ['stato' => '1', 'posizione_famiglia' => $posizione]);
             } else {
                 // TODO; check se la persona può essere asseganta alla nuova famiglia
-                DB::transaction(function () use (&$attuale, &$famiglia, &$data_uscita, &$data_entrata, &$posizione) {
+                DB::transaction(function () use (&$attuale, &$famiglia, &$posizione) {
                     DB::connection('db_nomadelfia')->update(
                         DB::raw("UPDATE famiglie_persone
-                        SET  data_uscita = :uscita, stato = '0'
+                        SET stato = '0'
                         WHERE persona_id  = :persona AND famiglia_id = :famiglia "),
-                        //  AND data_entrata = :entrata"), # TODO: mettere nella chiave primaria la data entrata ?
                         [
                             'persona' => $this->id,
                             'famiglia' => $attuale->id,
-                            'uscita' => ($data_uscita ? $data_uscita : $data_entrata),
                         ]
                     );
 
                     $this->famiglie()->attach($famiglia->id,
-                        ['stato' => '1', 'posizione_famiglia' => $posizione, 'data_entrata' => $data_entrata]);
+                        ['stato' => '1', 'posizione_famiglia' => $posizione]);
                 });
             }
         } catch (\Exception $e) {
@@ -888,7 +886,8 @@ class Persona extends Model
 
     public function assegnaNomadelfoEffettivo(
         Carbon\Carbon $data_inizio
-    ) {
+    )
+    {
         // TODO: check that the posizione attuale è postulante
         //        $attuale = this->posizioneAttuale();
         //        if $attuale && !$attuale->isPostulante){
@@ -902,7 +901,8 @@ class Persona extends Model
         $posizione,
         string $data_inizio,
         string $attuale_data_fine = null
-    ) {
+    )
+    {
         if (is_string($posizione) || is_int($posizione)) {
             $posizione = Posizione::findOrFail($posizione);
         }
@@ -929,7 +929,8 @@ class Persona extends Model
         $posizione_id,
         $currentDatain,
         $newDataIn
-    ) {
+    )
+    {
         $res = DB::connection('db_nomadelfia')->update(
             DB::raw('UPDATE persone_posizioni
                SET  data_inizio = :new
@@ -944,7 +945,8 @@ class Persona extends Model
         $posizione_id,
         $datain,
         $datafine
-    ) {
+    )
+    {
         $res = DB::connection('db_nomadelfia')->update(
             DB::raw("UPDATE persone_posizioni
                SET stato = '0', data_fine = :dataout
@@ -1000,17 +1002,18 @@ class Persona extends Model
     /**
      * Sposta una persona e la sua famiglia dal gruppo familiare attuale in un nuovo gruppo familiare.
      *
-     * @param  int|null  $gruppoFamiliareAttuale
-     * @param  date  $dataUscitaGruppoFamiliareAttuale
-     * @param  int  $gruppoFamiliareNuovo
-     * @param  date  $dataEntrataGruppo
+     * @param int|null $gruppoFamiliareAttuale
+     * @param date $dataUscitaGruppoFamiliareAttuale
+     * @param int $gruppoFamiliareNuovo
+     * @param date $dataEntrataGruppo
      */
     public function cambiaGruppoFamiliare(
         $gruppoFamiliareAttuale,
         $dataUscitaGruppoFamiliareAttuale,
         $gruppoFamiliareNuovo,
         $dataEntrataGruppo
-    ) {
+    )
+    {
         if ($this->isCapoFamiglia() or $this->isSingle()) {
             $this->famigliaAttuale()->assegnaFamigliaANuovoGruppoFamiliare($gruppoFamiliareAttuale,
                 $dataUscitaGruppoFamiliareAttuale, $gruppoFamiliareNuovo, $dataEntrataGruppo);
@@ -1022,7 +1025,8 @@ class Persona extends Model
         $dataUscitaGruppoFamiliareAttuale,
         $gruppoFamiliareNuovo,
         $dataEntrataGruppo = null
-    ) {
+    )
+    {
         try {
             $this->gruppifamiliari()->updateExistingPivot($gruppoFamiliareAttuale,
                 ['stato' => '0', 'data_uscita_gruppo' => $dataUscitaGruppoFamiliareAttuale]);

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/DecessoPersonaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/DecessoPersonaAction.php
@@ -14,10 +14,11 @@ class DecessoPersonaAction
     private SendEmailPersonaDecessoAction $email;
 
     public function __construct(
-        UscitaPersonaDBAction $uscita,
-        LogDecessoPersonaAction $logDecesso,
+        UscitaPersonaDBAction         $uscita,
+        LogDecessoPersonaAction       $logDecesso,
         SendEmailPersonaDecessoAction $email
-    ) {
+    )
+    {
         $this->uscita = $uscita;
         $this->logDecesso = $logDecesso;
         $this->email = $email;
@@ -59,8 +60,7 @@ class DecessoPersonaAction
 
             // aggiorna la data di uscita dalla famiglia con la data di decesso
             $conn->insert(
-                "UPDATE famiglie_persone SET data_uscita = ?, stato = '0' WHERE persona_id = ? AND stato = '1'",
-                [$data_decesso, $persona->id]
+                "UPDATE famiglie_persone SET stato = '0' WHERE persona_id = ? AND stato = '1'", [$persona->id]
             );
 
             DB::connection('db_nomadelfia')->commit();

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/DecessoPersonaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/DecessoPersonaAction.php
@@ -14,11 +14,10 @@ class DecessoPersonaAction
     private SendEmailPersonaDecessoAction $email;
 
     public function __construct(
-        UscitaPersonaDBAction         $uscita,
-        LogDecessoPersonaAction       $logDecesso,
+        UscitaPersonaDBAction $uscita,
+        LogDecessoPersonaAction $logDecesso,
         SendEmailPersonaDecessoAction $email
-    )
-    {
+    ) {
         $this->uscita = $uscita;
         $this->logDecesso = $logDecesso;
         $this->email = $email;

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataDallaNascitaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataDallaNascitaAction.php
@@ -15,8 +15,7 @@ class EntrataDallaNascitaAction
 
     public function __construct(
         EntrataPersonaAction $entrataInNomadelfiaAction
-    )
-    {
+    ) {
         $this->entrataInNomadelfiaAction = $entrataInNomadelfiaAction;
     }
 

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataDallaNascitaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataDallaNascitaAction.php
@@ -15,7 +15,8 @@ class EntrataDallaNascitaAction
 
     public function __construct(
         EntrataPersonaAction $entrataInNomadelfiaAction
-    ) {
+    )
+    {
         $this->entrataInNomadelfiaAction = $entrataInNomadelfiaAction;
     }
 
@@ -36,7 +37,6 @@ class EntrataDallaNascitaAction
 
     public function calcFamiglia(EntrataPersonaData $dto)
     {
-        $dto->famiglia_data = $dto->persona->data_nascita;
         $dto->famiglia_posizione = Famiglia::getFiglioNatoEnum();
     }
 

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMaggiorenneSingleAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMaggiorenneSingleAction.php
@@ -18,14 +18,13 @@ class EntrataMaggiorenneSingleAction
 
     public function __construct(
         EntrataPersonaAction $entrataInNomadelfiaAction
-    )
-    {
+    ) {
         $this->entrataInNomadelfiaAction = $entrataInNomadelfiaAction;
     }
 
     public function execute(Persona $persona, $data_entrata, GruppoFamiliare $gruppo)
     {
-        if (!$persona->isMaggiorenne()) {
+        if (! $persona->isMaggiorenne()) {
             throw PersonaIsMinorenne::named($persona->nominativo);
         }
 
@@ -44,7 +43,7 @@ class EntrataMaggiorenneSingleAction
 
     public function calcFamiglia(EntrataPersonaData $dto)
     {
-        $nome_famiglia = $dto->persona->nome . ' ' . Str::substr($dto->persona->cognome, 0, 2);
+        $nome_famiglia = $dto->persona->nome.' '.Str::substr($dto->persona->cognome, 0, 2);
         $data_famiglia = Carbon::parse($dto->persona->data_nascita)->addYears(18);
         $dto->famiglia = Famiglia::firstOrCreate(['nome_famiglia' => $nome_famiglia], ['data_creazione' => $data_famiglia->toDateString()]);
         $dto->famiglia_posizione = Famiglia::getSingleEnum();

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMaggiorenneSingleAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMaggiorenneSingleAction.php
@@ -18,13 +18,14 @@ class EntrataMaggiorenneSingleAction
 
     public function __construct(
         EntrataPersonaAction $entrataInNomadelfiaAction
-    ) {
+    )
+    {
         $this->entrataInNomadelfiaAction = $entrataInNomadelfiaAction;
     }
 
     public function execute(Persona $persona, $data_entrata, GruppoFamiliare $gruppo)
     {
-        if (! $persona->isMaggiorenne()) {
+        if (!$persona->isMaggiorenne()) {
             throw PersonaIsMinorenne::named($persona->nominativo);
         }
 
@@ -43,9 +44,9 @@ class EntrataMaggiorenneSingleAction
 
     public function calcFamiglia(EntrataPersonaData $dto)
     {
-        $nome_famiglia = $dto->persona->nome.' '.Str::substr($dto->persona->cognome, 0, 2);
-        $dto->famiglia_data = Carbon::parse($dto->persona->data_nascita)->addYears(18)->toDatestring();
-        $dto->famiglia = Famiglia::firstOrCreate(['nome_famiglia' => $nome_famiglia], ['data_creazione' => $dto->famiglia_data]);
+        $nome_famiglia = $dto->persona->nome . ' ' . Str::substr($dto->persona->cognome, 0, 2);
+        $data_famiglia = Carbon::parse($dto->persona->data_nascita)->addYears(18);
+        $dto->famiglia = Famiglia::firstOrCreate(['nome_famiglia' => $nome_famiglia], ['data_creazione' => $data_famiglia->toDateString()]);
         $dto->famiglia_posizione = Famiglia::getSingleEnum();
     }
 

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMinorenneAccoltoAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMinorenneAccoltoAction.php
@@ -15,8 +15,7 @@ class EntrataMinorenneAccoltoAction
 
     public function __construct(
         EntrataPersonaAction $entrataInNomadelfiaAction
-    )
-    {
+    ) {
         $this->entrataInNomadelfiaAction = $entrataInNomadelfiaAction;
     }
 

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMinorenneAccoltoAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMinorenneAccoltoAction.php
@@ -15,7 +15,8 @@ class EntrataMinorenneAccoltoAction
 
     public function __construct(
         EntrataPersonaAction $entrataInNomadelfiaAction
-    ) {
+    )
+    {
         $this->entrataInNomadelfiaAction = $entrataInNomadelfiaAction;
     }
 
@@ -36,7 +37,6 @@ class EntrataMinorenneAccoltoAction
 
     public function calcFamiglia(EntrataPersonaData $dto)
     {
-        $dto->famiglia_data = $dto->data_entrata;  // la data di entrata nella famiglia è uguale alla data di entrata in nomadelfia
         $dto->famiglia_posizione = Famiglia::getFiglioAccoltoEnum();
     }
 

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMinorenneConFamigliaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMinorenneConFamigliaAction.php
@@ -15,8 +15,7 @@ class EntrataMinorenneConFamigliaAction
 
     public function __construct(
         EntrataPersonaAction $entrataInNomadelfiaAction
-    )
-    {
+    ) {
         $this->entrataInNomadelfiaAction = $entrataInNomadelfiaAction;
     }
 

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMinorenneConFamigliaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataMinorenneConFamigliaAction.php
@@ -15,7 +15,8 @@ class EntrataMinorenneConFamigliaAction
 
     public function __construct(
         EntrataPersonaAction $entrataInNomadelfiaAction
-    ) {
+    )
+    {
         $this->entrataInNomadelfiaAction = $entrataInNomadelfiaAction;
     }
 
@@ -36,7 +37,6 @@ class EntrataMinorenneConFamigliaAction
 
     public function calcFamiglia(EntrataPersonaData $dto)
     {
-        $dto->famiglia_data = $dto->persona->data_nascita; // la data di entrata nella famiglia è uguale alla data di nascita
         $dto->famiglia_posizione = Famiglia::getFiglioNatoEnum();
     }
 

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataPersonaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataPersonaAction.php
@@ -12,10 +12,9 @@ class EntrataPersonaAction
     private SendEmailPersonaEntrataAction $email;
 
     public function __construct(
-        LogEntrataPersonaAction       $logEntrataInNomadelfiaActivityAction,
+        LogEntrataPersonaAction $logEntrataInNomadelfiaActivityAction,
         SendEmailPersonaEntrataAction $email
-    )
-    {
+    ) {
         $this->logEntrataInNomadelfiaActivityAction = $logEntrataInNomadelfiaActivityAction;
         $this->email = $email;
     }

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataPersonaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/EntrataPersonaAction.php
@@ -12,9 +12,10 @@ class EntrataPersonaAction
     private SendEmailPersonaEntrataAction $email;
 
     public function __construct(
-        LogEntrataPersonaAction $logEntrataInNomadelfiaActivityAction,
+        LogEntrataPersonaAction       $logEntrataInNomadelfiaActivityAction,
         SendEmailPersonaEntrataAction $email
-    ) {
+    )
+    {
         $this->logEntrataInNomadelfiaActivityAction = $logEntrataInNomadelfiaActivityAction;
         $this->email = $email;
     }
@@ -78,13 +79,11 @@ class EntrataPersonaAction
             // inserisce la persona nella famiglia con una posizione
             if ($entrataPersonaData->famiglia) {
                 // NOTE: se la persone è già nella famiglia (è duplicato) si aggiorna lo stato a 1 con la nuova data
-                $conn->insert("INSERT INTO famiglie_persone (famiglia_id, persona_id, data_entrata, posizione_famiglia, stato) VALUES (?, ?, ?, ?, '1')  ON DUPLICATE KEY UPDATE stato='1', data_entrata=?, data_uscita=NULL",
+                $conn->insert("INSERT INTO famiglie_persone (famiglia_id, persona_id, posizione_famiglia, stato) VALUES (?, ?, ?, '1')  ON DUPLICATE KEY UPDATE stato='1'",
                     [
                         $entrataPersonaData->famiglia->id,
                         $persona_id,
-                        $entrataPersonaData->famiglia_data,
                         $entrataPersonaData->famiglia_posizione,
-                        $entrataPersonaData->famiglia_data,
                     ]
                 );
             }

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/UscitaFamigliaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/UscitaFamigliaAction.php
@@ -13,10 +13,9 @@ class UscitaFamigliaAction
     private SendEmailFamigliaUscitaAction $emailUscita;
 
     public function __construct(
-        LogUscitaFamigliaAction       $logUscita,
+        LogUscitaFamigliaAction $logUscita,
         SendEmailFamigliaUscitaAction $emailUscita
-    )
-    {
+    ) {
         $this->logUscita = $logUscita;
         $this->emailUscita = $emailUscita;
     }

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/UscitaFamigliaAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/UscitaFamigliaAction.php
@@ -13,9 +13,10 @@ class UscitaFamigliaAction
     private SendEmailFamigliaUscitaAction $emailUscita;
 
     public function __construct(
-        LogUscitaFamigliaAction $logUscita,
+        LogUscitaFamigliaAction       $logUscita,
         SendEmailFamigliaUscitaAction $emailUscita
-    ) {
+    )
+    {
         $this->logUscita = $logUscita;
         $this->emailUscita = $emailUscita;
     }
@@ -24,7 +25,7 @@ class UscitaFamigliaAction
     {
         $dto = new UscitaFamigliaData();
         $dto->famiglia = $famiglia;
-        $dto->componenti = $famiglia->componentiAttuali()->orderBy('data_entrata')->get();
+        $dto->componenti = $famiglia->componentiAttuali()->get();
         $dto->data_uscita = $data_uscita;
 
         $this->save($dto);

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/UscitaPersonaDBAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/UscitaPersonaDBAction.php
@@ -44,6 +44,7 @@ class UscitaPersonaDBAction
                 [$uscitaPersonaData->data_uscita, $persona_id]
             );
 
+
             // conclude la persona nel gruppo familiare con la data di uscita
             $conn->insert(
                 "UPDATE gruppi_persone SET data_uscita_gruppo = ?, stato = '0' WHERE persona_id = ? AND stato = '1'",
@@ -67,12 +68,13 @@ class UscitaPersonaDBAction
                 [$uscitaPersonaData->data_uscita, $persona_id]
             );
 
+
             if ($uscitaPersonaData->persona->isFiglio() && $uscitaPersonaData->disableFromFamily) {
                 // caso: un figlio che esce dalla comunità da solo, deve essere tolto dal nucleo familiare.
                 //       Invece, un figlio che esce con la famiglia deve rimanere nel nucleo familiare d'origine.
                 $conn->insert(
-                    "UPDATE famiglie_persone  SET data_uscita = ?, stato = '0' WHERE persona_id = ? AND stato = '1'",
-                    [$uscitaPersonaData->data_uscita, $persona_id]
+                    "UPDATE famiglie_persone  SET stato = '0' WHERE persona_id = ? AND stato = '1'",
+                    [$persona_id]
                 );
             }
 
@@ -81,5 +83,6 @@ class UscitaPersonaDBAction
             DB::connection('db_nomadelfia')->rollback();
             throw $e;
         }
+
     }
 }

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/UscitaPersonaDBAction.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/Actions/UscitaPersonaDBAction.php
@@ -44,7 +44,6 @@ class UscitaPersonaDBAction
                 [$uscitaPersonaData->data_uscita, $persona_id]
             );
 
-
             // conclude la persona nel gruppo familiare con la data di uscita
             $conn->insert(
                 "UPDATE gruppi_persone SET data_uscita_gruppo = ?, stato = '0' WHERE persona_id = ? AND stato = '1'",
@@ -67,7 +66,6 @@ class UscitaPersonaDBAction
                 'UPDATE db_scuola.alunni_classi SET data_fine = ?  WHERE persona_id = ? AND data_fine IS NULL',
                 [$uscitaPersonaData->data_uscita, $persona_id]
             );
-
 
             if ($uscitaPersonaData->persona->isFiglio() && $uscitaPersonaData->disableFromFamily) {
                 // caso: un figlio che esce dalla comunità da solo, deve essere tolto dal nucleo familiare.

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/DataTransferObjects/EntrataPersonaData.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/DataTransferObjects/EntrataPersonaData.php
@@ -29,5 +29,4 @@ class EntrataPersonaData
     public ?Famiglia $famiglia = null;
 
     public ?string $famiglia_posizione;
-
 }

--- a/src/Domain/Nomadelfia/PopolazioneNomadelfia/DataTransferObjects/EntrataPersonaData.php
+++ b/src/Domain/Nomadelfia/PopolazioneNomadelfia/DataTransferObjects/EntrataPersonaData.php
@@ -30,5 +30,4 @@ class EntrataPersonaData
 
     public ?string $famiglia_posizione;
 
-    public ?string $famiglia_data;
 }

--- a/tests/Popolazione/Actions/AggiornamentoAnagrafeActionTest.php
+++ b/tests/Popolazione/Actions/AggiornamentoAnagrafeActionTest.php
@@ -23,7 +23,7 @@ it('save enter event into activity table', function () {
     $gruppo = GruppoFamiliare::first();
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
-    $famiglia->assegnaCapoFamiglia($capoFam, $data_entrata);
+    $famiglia->assegnaCapoFamiglia($capoFam);
 
     $action = app(LogEntrataPersonaAction::class);
 
@@ -94,7 +94,7 @@ it('save family exit into activity table', function () {
     $act->execute($capoFam, $now, $gruppo);
     $act = app(EntrataMaggiorenneConFamigliaAction::class);
     $act->execute($moglie, $now, $gruppo);
-    $famiglia->assegnaCapoFamiglia($capoFam, $now);
+    $famiglia->assegnaCapoFamiglia($capoFam);
     $famiglia->assegnaMoglie($moglie, $now);
     $act = app(EntrataDallaNascitaAction::class);
     $act->execute($fnato, Famiglia::findOrFail($famiglia->id));

--- a/tests/Popolazione/Actions/EmailAggiornamentoAnagrafeActionTest.php
+++ b/tests/Popolazione/Actions/EmailAggiornamentoAnagrafeActionTest.php
@@ -79,7 +79,7 @@ it('sends an email if a person enter', function () {
 
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
-    $famiglia->assegnaCapoFamiglia($capoFam, $data_entrata);
+    $famiglia->assegnaCapoFamiglia($capoFam);
 
     $action = app(EntrataMinorenneAccoltoAction::class);
     $action->execute($persona, $data_entrata, Famiglia::findOrFail($famiglia->id));

--- a/tests/Popolazione/Actions/EntrataUscitaActionTest.php
+++ b/tests/Popolazione/Actions/EntrataUscitaActionTest.php
@@ -18,7 +18,7 @@ it('entrata_minorenne_con_famiglia', function () {
 
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
-    $famiglia->assegnaCapoFamiglia($capoFam, $data_entrata);
+    $famiglia->assegnaCapoFamiglia($capoFam);
 
     $action = app(EntrataMinorenneConFamigliaAction::class);
     $action->execute($persona, $data_entrata, Famiglia::findOrFail($famiglia->id));
@@ -33,7 +33,6 @@ it('entrata_minorenne_con_famiglia', function () {
     expect($persona->gruppofamiliareAttuale()->id)->tobe($gruppo->id);
     expect($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo)->tobe($data_entrata);
     expect($persona->famigliaAttuale())->not->toBeNull();
-    expect($persona->famigliaAttuale()->pivot->data_entrata)->tobe($persona->data_nascita);
 
 });
 
@@ -46,7 +45,7 @@ it('entrata_minorenne_accolto', function () {
 
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
-    $famiglia->assegnaCapoFamiglia($capoFam, $data_entrata);
+    $famiglia->assegnaCapoFamiglia($capoFam);
 
     $action = app(EntrataMinorenneAccoltoAction::class);
     $action->execute($persona, $data_entrata, Famiglia::findOrFail($famiglia->id));

--- a/tests/Popolazione/Http/AggiornamentoAnagrafeTest.php
+++ b/tests/Popolazione/Http/AggiornamentoAnagrafeTest.php
@@ -16,7 +16,7 @@ it('show aggiornamento anagrafe index', function () {
     $gruppo = GruppoFamiliare::first();
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
-    $famiglia->assegnaCapoFamiglia($capoFam, $data_entrata);
+    $famiglia->assegnaCapoFamiglia($capoFam);
 
     $action = app(LogEntrataPersonaAction::class);
 

--- a/tests/Popolazione/Http/PersoneEntrataControllerTest.php
+++ b/tests/Popolazione/Http/PersoneEntrataControllerTest.php
@@ -26,7 +26,7 @@ it('it_can_insert_minorenne_accolto_nella_popolazione', function () {
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $act = app(EntrataMaggiorenneConFamigliaAction::class);
     $act->execute($capoFam, $data_entrata, $gruppo);
-    $famiglia->assegnaCapoFamiglia($capoFam, $data_entrata);
+    $famiglia->assegnaCapoFamiglia($capoFam);
 
     login();
     $this->withoutExceptionHandling();
@@ -51,7 +51,6 @@ it('it_can_insert_minorenne_accolto_nella_popolazione', function () {
     $this->assertEquals($persona->gruppofamiliareAttuale()->id, $gruppo->id);
     $this->assertEquals($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo, $data_entrata);
     $this->assertNotNull($persona->famigliaAttuale());
-    $this->assertEquals($persona->famigliaAttuale()->pivot->data_entrata, $data_entrata);
     $this->assertEquals($persona->famigliaAttuale()->pivot->posizione_famiglia, Famiglia::getFiglioAccoltoEnum());
 });
 
@@ -64,7 +63,7 @@ it('it_can_insert_minorenne_con_famiglia_nella_popolazione', function () {
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $act = app(EntrataMaggiorenneConFamigliaAction::class);
     $act->execute($capoFam, $data_entrata, $gruppo);
-    $famiglia->assegnaCapoFamiglia($capoFam, $data_entrata);
+    $famiglia->assegnaCapoFamiglia($capoFam);
 
     login();
     $this->post(action([PersonaEntrataController::class, 'store'], ['idPersona' => $persona->id]),
@@ -86,7 +85,6 @@ it('it_can_insert_minorenne_con_famiglia_nella_popolazione', function () {
     $this->assertEquals($persona->gruppofamiliareAttuale()->id, $gruppo->id);
     $this->assertEquals($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo, $data_entrata);
     $this->assertNotNull($persona->famigliaAttuale());
-    $this->assertEquals($persona->famigliaAttuale()->pivot->data_entrata, $data_nascita->toDateString());
     $this->assertEquals($persona->famigliaAttuale()->pivot->posizione_famiglia, Famiglia::getFiglioNatoEnum());
 });
 
@@ -98,7 +96,7 @@ it('entrata_persona_dalla_nascita', function () {
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $act = app(EntrataMaggiorenneConFamigliaAction::class);
     $act->execute($capoFam, Carbon::now()->toDatestring(), $gruppo);
-    $famiglia->assegnaCapoFamiglia($capoFam, Carbon::now()->toDatestring());
+    $famiglia->assegnaCapoFamiglia($capoFam);
 
     login();
     $this->withoutExceptionHandling();
@@ -120,7 +118,6 @@ it('entrata_persona_dalla_nascita', function () {
     $this->assertEquals($persona->gruppofamiliareAttuale()->id, $gruppo->id);
     $this->assertEquals($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo, $data_nascita->toDatestring());
     $this->assertNotNull($persona->famigliaAttuale());
-    $this->assertEquals($persona->famigliaAttuale()->pivot->data_entrata, $data_nascita->toDatestring());
     $this->assertEquals($persona->famigliaAttuale()->pivot->posizione_famiglia, Famiglia::getFiglioNatoEnum());
 });
 

--- a/tests/Popolazione/Unit/FamigliaTest.php
+++ b/tests/Popolazione/Unit/FamigliaTest.php
@@ -18,7 +18,7 @@ use InvalidArgumentException;
 it('throws and invalidArgument on assign a component', function () {
     $famiglia = Famiglia::factory()->create();
     $persona = Persona::factory()->maggiorenne()->maschio()->create();
-    $famiglia->assegnaComponente($persona, 'NOT EXISTING', Carbon::now()->toDatestring());
+    $famiglia->assegnaComponente($persona, 'NOT EXISTING');
 })->throws(InvalidArgumentException::class);
 
 it('assign a component', function () {
@@ -26,31 +26,29 @@ it('assign a component', function () {
     $famiglia = Famiglia::factory()->create();
     $persona = Persona::factory()->maggiorenne()->maschio()->create();
     $now = Carbon::now()->toDatestring();
-    $famiglia->assegnaComponente($persona, $famiglia::getCapoFamigliaEnum(), $now);
-    expect($famiglia->capofamiglia()->pivot->data_entrata)->toBe($now);
+    $famiglia->assegnaComponente($persona, $famiglia::getCapoFamigliaEnum());
+    expect($famiglia->capofamiglia()->id)->toBe($persona->id);
 
     // test assegna MOGLIE
     $famiglia = Famiglia::factory()->create();
     $persona = Persona::factory()->maggiorenne()->femmina()->create();
     $now = Carbon::now()->toDatestring();
-    $famiglia->assegnaComponente($persona, $famiglia::getMoglieEnum(), $now);
-    expect($famiglia->moglie()->pivot->data_entrata)->toBe($now);
+    $famiglia->assegnaComponente($persona, $famiglia::getMoglieEnum());
+    expect($famiglia->moglie()->id)->toBe($persona->id);
 });
 
 it('throws and expection with bad capo famiglia', function () {
     $famiglia = Famiglia::factory()->create();
     $minorenne = Persona::factory()->minorenne()->maschio()->create();
-    $now = Carbon::now()->toDatestring();
-    $famiglia->assegnaCapoFamiglia($minorenne, $now);
+    $famiglia->assegnaCapoFamiglia($minorenne);
 })->throws(CouldNotAssignCapoFamiglia::class);
 
 it('throw exceptions  with already capo famiglia', function () {
     $famiglia = Famiglia::factory()->create();
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
-    $now = Carbon::now()->toDatestring();
-    $famiglia->assegnaCapoFamiglia($capoFam, $now);
+    $famiglia->assegnaCapoFamiglia($capoFam);
     $newCapoFam = Persona::factory()->maggiorenne()->maschio()->create();
-    $famiglia->assegnaCapoFamiglia($newCapoFam, $now);
+    $famiglia->assegnaCapoFamiglia($newCapoFam);
 })->throws(CouldNotAssignCapoFamiglia::class);
 
 it('throw expection with multiple mogli', function () {
@@ -89,7 +87,6 @@ it('assign a wife succesfully', function () {
     $persona = Persona::factory()->maggiorenne()->femmina()->create();
     $famiglia->assegnaMoglie($persona);
     expect($persona->id)->toBe($famiglia->moglie()->id);
-    expect($famiglia->data_creazione)->toBe($famiglia->moglie()->pivot->data_entrata);
 
     //moglie
     $famiglia = Famiglia::factory()->create();
@@ -97,7 +94,6 @@ it('assign a wife succesfully', function () {
     $now = Carbon::now()->toDatestring();
     $famiglia->assegnaMoglie($persona, $now);
     expect($famiglia->moglie()->id)->toBe($persona->id);
-    expect($now)->toBe($famiglia->moglie()->pivot->data_entrata);
 });
 
 /**
@@ -119,7 +115,7 @@ it('exit a children from family', function () {
     $act->execute($capoFam, $now, $gruppo);
     $act = app(EntrataMaggiorenneConFamigliaAction::class);
     $act->execute($moglie, $now, $gruppo);
-    $famiglia->assegnaCapoFamiglia($capoFam, $now);
+    $famiglia->assegnaCapoFamiglia($capoFam);
     $famiglia->assegnaMoglie($moglie, $now);
 
     $act = app(EntrataDallaNascitaAction::class);

--- a/tests/Popolazione/Unit/PersonaTest.php
+++ b/tests/Popolazione/Unit/PersonaTest.php
@@ -57,7 +57,7 @@ it('testEntrataMaschioDallaNascita', function () {  /*
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
     $famiglia->componenti()->attach($capoFam->id,
-        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA', 'data_entrata' => Carbon::now()->toDatestring()]);
+        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA']);
 
     $act = app(EntrataDallaNascitaAction::class);
     $act->execute($persona, Famiglia::findOrFail($famiglia->id));
@@ -72,7 +72,7 @@ it('testEntrataMaschioDallaNascita', function () {  /*
         ->and($persona->gruppofamiliareAttuale()->id)->toBe($gruppo->id)
         ->and($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo)->toBe($persona->data_nascita)
         ->and($persona->famigliaAttuale())->not->toBeNull()
-        ->and($persona->famigliaAttuale()->pivot->data_entrata)->toBe($persona->data_nascita);
+        ->and($persona->famigliaAttuale()->id)->toBe($famiglia->id);
 });
 
 it('testEntrataFemminaDallaNascita', function () {
@@ -87,7 +87,7 @@ it('testEntrataFemminaDallaNascita', function () {
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
     $famiglia->componenti()->attach($capoFam->id,
-        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA', 'data_entrata' => Carbon::now()->toDatestring()]);
+        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA']);
 
     $act = app(EntrataDallaNascitaAction::class);
     $act->execute($persona, Famiglia::findOrFail($famiglia->id));
@@ -102,7 +102,7 @@ it('testEntrataFemminaDallaNascita', function () {
         ->and($persona->gruppofamiliareAttuale()->id)->toBe($gruppo->id)
         ->and($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo)->toBe($persona->data_nascita);
     $this->assertNotNull($persona->famigliaAttuale());
-    expect($persona->famigliaAttuale()->pivot->data_entrata)->toBe($persona->data_nascita);
+    expect($persona->famigliaAttuale()->id)->toBe($famiglia->id);
 });
 
 it('testEntrataMinorenneFemminaAccolto', function () {
@@ -117,7 +117,7 @@ it('testEntrataMinorenneFemminaAccolto', function () {
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
     $famiglia->componenti()->attach($capoFam->id,
-        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA', 'data_entrata' => Carbon::now()->toDatestring()]);
+        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA']);
 
     //        $persona->entrataMinorenneAccolto($data_entrata, $famiglia->id);
     $act = app(EntrataMinorenneAccoltoAction::class);
@@ -140,7 +140,7 @@ it('testEntrataMinorenneFemminaAccolto', function () {
         ->and($persona->gruppofamiliareAttuale()->id)->toBe($gruppo->id)
         ->and($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo)->toBe($data_entrata);
     $this->assertNotNull($persona->famigliaAttuale());
-    expect($persona->famigliaAttuale()->pivot->data_entrata)->toBe($data_entrata);
+    expect($persona->famigliaAttuale()->id)->toBe($famiglia->id);
 });
 
 it('testEntrataMinorenneMaschioAccolto', function () {
@@ -155,7 +155,7 @@ it('testEntrataMinorenneMaschioAccolto', function () {
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
     $famiglia->componenti()->attach($capoFam->id,
-        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA', 'data_entrata' => Carbon::now()->toDatestring()]);
+        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA']);
 
     $act = app(EntrataMinorenneAccoltoAction::class);
     $act->execute($persona, $data_entrata, $famiglia);
@@ -178,7 +178,7 @@ it('testEntrataMinorenneMaschioAccolto', function () {
         ->and($persona->gruppofamiliareAttuale()->id)->toBe($gruppo->id)
         ->and($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo)->toBe($data_entrata);
     $this->assertNotNull($persona->famigliaAttuale());
-    expect($persona->famigliaAttuale()->pivot->data_entrata)->toBe($data_entrata);
+    expect($persona->famigliaAttuale()->id)->toBe($famiglia->id);
 });
 
 it('testEntrataMinorenneFemminaConFamiglia', function () {
@@ -193,7 +193,7 @@ it('testEntrataMinorenneFemminaConFamiglia', function () {
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
     $famiglia->componenti()->attach($capoFam->id,
-        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA', 'data_entrata' => Carbon::now()->toDatestring()]);
+        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA']);
 
     $action = app(EntrataMinorenneConFamigliaAction::class);
     $action->execute($persona, $data_entrata, Famiglia::findOrFail($famiglia->id));
@@ -215,7 +215,7 @@ it('testEntrataMinorenneFemminaConFamiglia', function () {
         ->and($persona->gruppofamiliareAttuale()->id)->toBe($gruppo->id)
         ->and($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo)->toBe($data_entrata);
     $this->assertNotNull($persona->famigliaAttuale());
-    expect($persona->famigliaAttuale()->pivot->data_entrata)->toBe($persona->data_nascita);
+    expect($persona->famigliaAttuale()->id)->toBe($famiglia->id);
 });
 
 it('testEntrataMinorenneMaschioConFamiglia', function () {
@@ -230,7 +230,7 @@ it('testEntrataMinorenneMaschioConFamiglia', function () {
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
     $famiglia->componenti()->attach($capoFam->id,
-        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA', 'data_entrata' => Carbon::now()->toDatestring()]);
+        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA']);
 
     $action = app(EntrataMinorenneConFamigliaAction::class);
     $action->execute($persona, $data_entrata, Famiglia::findOrFail($famiglia->id));
@@ -252,7 +252,7 @@ it('testEntrataMinorenneMaschioConFamiglia', function () {
         ->and($persona->gruppofamiliareAttuale()->id)->toBe($gruppo->id)
         ->and($persona->gruppofamiliareAttuale()->pivot->data_entrata_gruppo)->toBe($data_entrata);
     $this->assertNotNull($persona->famigliaAttuale());
-    expect($persona->famigliaAttuale()->pivot->data_entrata)->toBe($persona->data_nascita);
+    expect($persona->famigliaAttuale()->id)->toBe($famiglia->id);
 });
 
 it('testEntrataMaggiorenneMaschioSingle', function () {
@@ -331,7 +331,7 @@ it('testRientroMaggiorenneInNomadelfia', function () {
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
     $capoFam->gruppifamiliari()->attach($gruppo->id, ['stato' => '1', 'data_entrata_gruppo' => $data_entrata]);
     $famiglia->componenti()->attach($capoFam->id,
-        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA', 'data_entrata' => Carbon::now()->toDatestring()]);
+        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA']);
 
     // la persona nasce in Nomadelfia
     $act = app(EntrataDallaNascitaAction::class);
@@ -385,6 +385,7 @@ it('testRientroMinorenneInNuovaFamigliaNomadelfia', function () {
     $this->assertFalse($figlio->isPersonaInterna());
     expect($figlio->getDataEntrataNomadelfia())->toBe($data_entrata->toDatestring());
     expect($figlio->getDataUscitaNomadelfia())->toBe($data_uscita);
+
 
     // la persona rientra in Nomadelfia in una nuova famiglia
     $famiglia_rientro = Famiglia::factory()->create();

--- a/tests/Popolazione/Unit/PersonaTest.php
+++ b/tests/Popolazione/Unit/PersonaTest.php
@@ -386,7 +386,6 @@ it('testRientroMinorenneInNuovaFamigliaNomadelfia', function () {
     expect($figlio->getDataEntrataNomadelfia())->toBe($data_entrata->toDatestring());
     expect($figlio->getDataUscitaNomadelfia())->toBe($data_uscita);
 
-
     // la persona rientra in Nomadelfia in una nuova famiglia
     $famiglia_rientro = Famiglia::factory()->create();
     $cp = Persona::factory()->maggiorenne()->create();

--- a/tests/Popolazione/Unit/PopolazioneTest.php
+++ b/tests/Popolazione/Unit/PopolazioneTest.php
@@ -44,8 +44,7 @@ it('remove dead person from population', function () {
     expect($persona->statiStorico()->get()->last()->pivot->data_fine)->toBe($data_decesso);
     $this->assertNull($persona->gruppofamiliareAttuale());
     expect($persona->gruppofamiliariStorico()->get()->last()->pivot->data_uscita_gruppo)->toBe($data_decesso)
-        ->and($persona->famigliaAttuale())->toBeNull()
-        ->and($persona->famiglieStorico()->get()->last()->pivot->data_uscita)->toBe($data_decesso);
+        ->and($persona->famigliaAttuale())->toBeNull();
 
     $pop = PopolazioneNomadelfia::popolazione();
     expect(count($pop))->toBe($tot - 1);
@@ -109,7 +108,7 @@ it('manage exit of underage', function () {
     $capoFam->gruppifamiliari()->attach($gruppo->id,
         ['stato' => '1', 'data_entrata_gruppo' => Carbon::now()->subYears(10)->toDatestring()]);
     $famiglia->componenti()->attach($capoFam->id,
-        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA', 'data_entrata' => Carbon::now()->toDatestring()]);
+        ['stato' => '1', 'posizione_famiglia' => 'CAPO FAMIGLIA']);
 
     $act = app(EntrataDallaNascitaAction::class);
     $act->execute($persona, Famiglia::findOrFail($famiglia->id));
@@ -139,7 +138,7 @@ it('manage exit of underage', function () {
         ->and($persona->gruppofamiliareAttuale())->toBeNull()
         ->and($persona->gruppofamiliariStorico()->get()->last()->pivot->data_uscita_gruppo)->toBe($data_uscita)
         ->and($persona->famigliaAttuale())->toBeNull()
-        ->and($persona->famiglieStorico()->get()->last()->pivot->data_uscita)->toBe($data_uscita)
+        ->and($persona->famiglieStorico()->get()->last()->id)->toBe($famiglia->id)
         ->and($classe->alunni()->count())->toBe(0);
 
     $pop = PopolazioneNomadelfia::popolazione();
@@ -165,7 +164,7 @@ it('manage exit of family', function () {
     $act->execute($capoFam, $now, $gruppo);
     $act = app(EntrataMaggiorenneConFamigliaAction::class);
     $act->execute($moglie, $now, $gruppo);
-    $famiglia->assegnaCapoFamiglia($capoFam, $now);
+    $famiglia->assegnaCapoFamiglia($capoFam);
     $famiglia->assegnaMoglie($moglie, $now);
     $act = app(EntrataDallaNascitaAction::class);
     $act->execute($fnato, Famiglia::findOrFail($famiglia->id));
@@ -208,7 +207,7 @@ it('manage people not part of family when it exits', function () {
     $act->execute($capoFam, $now, $gruppo);
     $act = app(EntrataMaggiorenneConFamigliaAction::class);
     $act->execute($moglie, $now, $gruppo);
-    $famiglia->assegnaCapoFamiglia($capoFam, $now);
+    $famiglia->assegnaCapoFamiglia($capoFam);
     $famiglia->assegnaMoglie($moglie, $now);
 
     $act = app(EntrataDallaNascitaAction::class);
@@ -241,7 +240,7 @@ it('count the underages of the population', function () {
     $now = Carbon::now()->toDatestring();
     $famiglia = Famiglia::factory()->create();
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
-    $famiglia->assegnaCapoFamiglia($capoFam, $now);
+    $famiglia->assegnaCapoFamiglia($capoFam);
     $gruppo = GruppoFamiliare::all()->random();
     $capoFam->assegnaGruppoFamiliare($gruppo, $now);
 
@@ -288,7 +287,7 @@ it('returns the figli between two ages', function () {
 
     $famiglia = Famiglia::factory()->create();
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
-    $famiglia->assegnaCapoFamiglia($capoFam, Carbon::now());
+    $famiglia->assegnaCapoFamiglia($capoFam);
     $capoFam->assegnaGruppoFamiliare(GruppoFamiliare::all()->random(), Carbon::now());
 
     $p1 = Persona::factory()->create(['data_nascita' => Carbon::now()->subYears(3)->startOfYear()]); // 2018-01-01 00:00:00

--- a/tests/Scuola/Unit/ScuolaTest.php
+++ b/tests/Scuola/Unit/ScuolaTest.php
@@ -231,7 +231,7 @@ it('get possible students in year', function () {
     $famiglia = Famiglia::factory()->create();
     $gruppo = GruppoFamiliare::all()->random();
     $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
-    $famiglia->assegnaCapoFamiglia($capoFam, Carbon::now());
+    $famiglia->assegnaCapoFamiglia($capoFam);
     $act = app(EntrataMaggiorenneConFamigliaAction::class);
     $act->execute($capoFam, Carbon::now()->toDateString(), $gruppo);
 


### PR DESCRIPTION
## Motivation
The dates `data_entrata` and `data_uscita` of the familly were not needed, in all the cases the dates were "duplicates" dates:
- entrataDallaNacita => the data_entrata is equal to the birth date
- entrataMaggiorenneSingle => the data_entrata = persona->data_nascita + 18 years (not always true)
- entrataMinorenneAccolto => the data_entrata is equal to the data entrata in nomadelfia
- entrataMinorenneConFamiglia => the data_entrata is equal to the data_nascita
- decesso => data_uscita was equal to the death date
- uscita => data_uscita from family is equal to the data_uscita from the nomadelfia.

 The columns are not deleted but renamed with a `deleteme_*` prefix
