### PR TITLE
fix: inject assets to every page cause high response time 

### DIFF
--- a/config/livewire-tables.php
+++ b/config/livewire-tables.php
@@ -5,4 +5,15 @@ return [
      * Options: tailwind | bootstrap-4 | bootstrap-5.
      */
     'theme' => 'bootstrap-4',
+
+    /**
+     * Enable or Disable automatic injection of core assets
+     */
+    'inject_core_assets_enabled' => false,
+
+    /**
+     * Enable or Disable automatic injection of third-party assets
+     */
+    'inject_third_party_assets_enabled' => false,
+
 ];


### PR DESCRIPTION
## Motivation
After upgrading the [livewire-table](https://rappasoft.com/docs/laravel-livewire-tables/v3/introduction) using livewire 3, come configs enable by default, trigger the injection of the `css` and `js` assets to every request and these assets are not cached by the browser.

This introduces 3 seconds delay to load a page.

## Solution
Diable the injection