### PR TITLE
chore(execptions):  report expection with a blade view with informative message.

### DIFF
--- a/resources/views/errors/401.blade.php
+++ b/resources/views/errors/401.blade.php
@@ -1,4 +1,4 @@
-@extends("errors::layout")
+@extends("errors.layout")
 
 @section("title", "Error")
 

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,4 +1,4 @@
-@extends("errors::layout")
+@extends("errors.layout")
 
 @section("title", "Error")
 

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,4 +1,4 @@
-@extends("errors::layout")
+@extends("errors.layout")
 
 @section("title", "Error")
 

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,4 +1,4 @@
-@extends("errors::layout")
+@extends("errors.layout")
 
 @section("title", "Error")
 

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -1,4 +1,4 @@
-@extends("errors::layout")
+@extends("errors.layout")
 
 @section("title", "Error")
 

--- a/resources/views/errors/layout.blade.php
+++ b/resources/views/errors/layout.blade.php
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <title>@yield('title')</title>
+
+        <!-- Styles -->
+        <style>
+            html, body {
+                background-color: #fff;
+                color: #636b6f;
+                font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+                font-weight: 100;
+                height: 100vh;
+                margin: 0;
+            }
+
+            .full-height {
+                height: 100vh;
+            }
+
+            .flex-center {
+                align-items: center;
+                display: flex;
+                justify-content: center;
+            }
+
+            .position-ref {
+                position: relative;
+            }
+
+            .content {
+                text-align: center;
+            }
+
+            .title {
+                font-size: 36px;
+                padding: 20px;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="flex-center position-ref full-height">
+            <div class="content">
+                <div class="title">
+                    @yield('message')
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/resources/views/errors/layout.blade.php
+++ b/resources/views/errors/layout.blade.php
@@ -1,17 +1,32 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-        <title>@yield('title')</title>
+        <title>@yield("title")</title>
 
         <!-- Styles -->
         <style>
-            html, body {
+            html,
+            body {
                 background-color: #fff;
                 color: #636b6f;
-                font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+                font-family:
+                    ui-sans-serif,
+                    system-ui,
+                    -apple-system,
+                    BlinkMacSystemFont,
+                    'Segoe UI',
+                    Roboto,
+                    'Helvetica Neue',
+                    Arial,
+                    'Noto Sans',
+                    sans-serif,
+                    'Apple Color Emoji',
+                    'Segoe UI Emoji',
+                    'Segoe UI Symbol',
+                    'Noto Color Emoji';
                 font-weight: 100;
                 height: 100vh;
                 margin: 0;
@@ -45,7 +60,7 @@
         <div class="flex-center position-ref full-height">
             <div class="content">
                 <div class="title">
-                    @yield('message')
+                    @yield("message")
                 </div>
             </div>
         </div>

--- a/resources/views/errors/sin-error.blade.php
+++ b/resources/views/errors/sin-error.blade.php
@@ -1,4 +1,4 @@
-@extends("errors::layout")
+@extends("errors.layout")
 
 @section("title", "SIN Error")
 

--- a/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignAzienda.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignAzienda.php
@@ -4,9 +4,8 @@ namespace App\Nomadelfia\Exceptions;
 
 use Domain\Nomadelfia\Azienda\Models\Azienda;
 use Domain\Nomadelfia\Persona\Models\Persona;
-use Exception;
 
-class CouldNotAssignAzienda extends Exception
+class CouldNotAssignAzienda extends NomadelfiaException
 {
     public static function isAlreadyWorkingIntozienda(Azienda $azienda, Persona $persona): CouldNotAssignAzienda
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignCapoFamiglia.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignCapoFamiglia.php
@@ -4,9 +4,8 @@ namespace App\Nomadelfia\Exceptions;
 
 use Domain\Nomadelfia\Famiglia\Models\Famiglia;
 use Domain\Nomadelfia\Persona\Models\Persona;
-use Exception;
 
-class CouldNotAssignCapoFamiglia extends Exception
+class CouldNotAssignCapoFamiglia extends NomadelfiaException
 {
     public static function hasAlreadyCapoFamiglia(Famiglia $famiglia, Persona $capofamiglia): CouldNotAssignCapoFamiglia
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignCapogruppo.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignCapogruppo.php
@@ -4,9 +4,8 @@ namespace App\Nomadelfia\Exceptions;
 
 use Domain\Nomadelfia\GruppoFamiliare\Models\GruppoFamiliare;
 use Domain\Nomadelfia\Persona\Models\Persona;
-use Exception;
 
-class CouldNotAssignCapogruppo extends Exception
+class CouldNotAssignCapogruppo extends NomadelfiaException
 {
     public static function isNotEffetivo(Persona $persona): CouldNotAssignCapogruppo
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignCarica.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignCarica.php
@@ -3,9 +3,8 @@
 namespace App\Nomadelfia\Exceptions;
 
 use Domain\Nomadelfia\Persona\Models\Persona;
-use Exception;
 
-class CouldNotAssignCarica extends Exception
+class CouldNotAssignCarica extends NomadelfiaException
 {
     public static function presidenteAssociazioneAlreadySet(Persona $persona): CouldNotAssignCarica
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignIncarico.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignIncarico.php
@@ -5,9 +5,8 @@ namespace App\Nomadelfia\Exceptions;
 use Domain\Nomadelfia\Azienda\Models\Azienda;
 use Domain\Nomadelfia\Incarico\Models\Incarico;
 use Domain\Nomadelfia\Persona\Models\Persona;
-use Exception;
 
-class CouldNotAssignIncarico extends Exception
+class CouldNotAssignIncarico extends NomadelfiaException
 {
     public static function hasAlreadyIncarico(Incarico $incarico, Persona $persona): CouldNotAssignIncarico
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignMoglie.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/CouldNotAssignMoglie.php
@@ -4,9 +4,8 @@ namespace App\Nomadelfia\Exceptions;
 
 use Domain\Nomadelfia\Famiglia\Models\Famiglia;
 use Domain\Nomadelfia\Persona\Models\Persona;
-use Exception;
 
-class CouldNotAssignMoglie extends Exception
+class CouldNotAssignMoglie extends NomadelfiaException
 {
     public static function hasAlreadyMoglie(Famiglia $famiglia, Persona $persona): CouldNotAssignMoglie
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/EsSpiritualeNotActive.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/EsSpiritualeNotActive.php
@@ -3,9 +3,8 @@
 namespace App\Nomadelfia\Exceptions;
 
 use Domain\Nomadelfia\EserciziSpirituali\Models\EserciziSpirituali;
-use InvalidArgumentException;
 
-class EsSpiritualeNotActive extends InvalidArgumentException
+class EsSpiritualeNotActive extends NomadelfiaException
 {
     public static function named(EserciziSpirituali $es): EsSpiritualeNotActive
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/FamigliaHasMultipleGroup.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/FamigliaHasMultipleGroup.php
@@ -3,9 +3,8 @@
 namespace App\Nomadelfia\Exceptions;
 
 use Domain\Nomadelfia\Famiglia\Models\Famiglia;
-use InvalidArgumentException;
 
-class FamigliaHasMultipleGroup extends InvalidArgumentException
+class FamigliaHasMultipleGroup extends NomadelfiaException
 {
     public static function named(Famiglia $famiglia): FamigliaHasMultipleGroup
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/FamigliaHasNoGroup.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/FamigliaHasNoGroup.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class FamigliaHasNoGroup extends InvalidArgumentException
+class FamigliaHasNoGroup extends NomadelfiaException
 {
     public static function named(string $nome): FamigliaHasNoGroup
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/GruppoFamiliareDoesNotExists.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/GruppoFamiliareDoesNotExists.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class GruppoFamiliareDoesNotExists extends InvalidArgumentException
+class GruppoFamiliareDoesNotExists extends NomadelfiaException
 {
     public static function named(string $nome): GruppoFamiliareDoesNotExists
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/GruppoHaMultipleCapogruppi.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/GruppoHaMultipleCapogruppi.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class GruppoHaMultipleCapogruppi extends InvalidArgumentException
+class GruppoHaMultipleCapogruppi extends NomadelfiaException
 {
     public static function named(string $nome): GruppoHaMultipleCapogruppi
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/NomadelfiaException.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/NomadelfiaException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Nomadelfia\Exceptions;
+
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+abstract class NomadelfiaException extends Exception {
+
+   public function render(Request $request): Response
+   {
+        $exception = $this;
+        return response()->view('errors.sinError', compact('exception'), 500);
+   }
+
+}

--- a/src/App/Sin/Nomadelfia/Exceptions/NomadelfiaException.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/NomadelfiaException.php
@@ -12,6 +12,6 @@ abstract class NomadelfiaException extends Exception
     {
         $exception = $this;
 
-        return response()->view('errors.sinError', compact('exception'), 500);
+        return response()->view('errors.sin-error', compact('exception'), 500);
     }
 }

--- a/src/App/Sin/Nomadelfia/Exceptions/NomadelfiaException.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/NomadelfiaException.php
@@ -6,12 +6,12 @@ use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
-abstract class NomadelfiaException extends Exception {
-
-   public function render(Request $request): Response
-   {
+abstract class NomadelfiaException extends Exception
+{
+    public function render(Request $request): Response
+    {
         $exception = $this;
-        return response()->view('errors.sinError', compact('exception'), 500);
-   }
 
+        return response()->view('errors.sinError', compact('exception'), 500);
+    }
 }

--- a/src/App/Sin/Nomadelfia/Exceptions/PersonaErrors.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/PersonaErrors.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class PersonaErrors extends InvalidArgumentException
+class PersonaErrors extends NomadelfiaException
 {
     public static function named(string $nome): PersonaErrors
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultipleCategorieAttuale.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultipleCategorieAttuale.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class PersonaHasMultipleCategorieAttuale extends InvalidArgumentException
+class PersonaHasMultipleCategorieAttuale extends NomadelfiaException
 {
     public static function named(string $nome): PersonaHasMultipleCategorieAttuale
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultipleFamigliaAttuale.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultipleFamigliaAttuale.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class PersonaHasMultipleFamigliaAttuale extends InvalidArgumentException
+class PersonaHasMultipleFamigliaAttuale extends NomadelfiaException
 {
     public static function named(string $nome): PersonaHasMultipleFamigliaAttuale
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultipleGroup.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultipleGroup.php
@@ -3,9 +3,8 @@
 namespace App\Nomadelfia\Exceptions;
 
 use Domain\Nomadelfia\Persona\Models\Persona;
-use InvalidArgumentException;
 
-class PersonaHasMultipleGroup extends InvalidArgumentException
+class PersonaHasMultipleGroup extends NomadelfiaException
 {
     public static function named(Persona $persona): PersonaHasMultipleGroup
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultiplePosizioniAttuale.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultiplePosizioniAttuale.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class PersonaHasMultiplePosizioniAttuale extends InvalidArgumentException
+class PersonaHasMultiplePosizioniAttuale extends NomadelfiaException
 {
     public static function named(string $nome): PersonaHasMultiplePosizioniAttuale
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultipleStatoAttuale.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/PersonaHasMultipleStatoAttuale.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class PersonaHasMultipleStatoAttuale extends InvalidArgumentException
+class PersonaHasMultipleStatoAttuale extends NomadelfiaException
 {
     public static function named(string $nome): PersonaHasMultipleStatoAttuale
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/PersonaHasNoGroup.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/PersonaHasNoGroup.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class PersonaHasNoGroup extends InvalidArgumentException
+class PersonaHasNoGroup extends NomadelfiaException
 {
     public static function named(string $nome): PersonaHasNoGroup
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/PersonaIsMinorenne.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/PersonaIsMinorenne.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class PersonaIsMinorenne extends InvalidArgumentException
+class PersonaIsMinorenne extends NomadelfiaException
 {
     public static function named(string $nome): PersonaIsMinorenne
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/PosizioneDoesNotExists.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/PosizioneDoesNotExists.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class PosizioneDoesNotExists extends InvalidArgumentException
+class PosizioneDoesNotExists extends NomadelfiaException
 {
     public static function named(string $nome): PosizioneDoesNotExists
     {

--- a/src/App/Sin/Nomadelfia/Exceptions/SpostaNellaFamigliaError.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/SpostaNellaFamigliaError.php
@@ -4,26 +4,11 @@ namespace App\Nomadelfia\Exceptions;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use InvalidArgumentException;
 
-class SpostaNellaFamigliaError extends InvalidArgumentException
+class SpostaNellaFamigliaError extends NomadelfiaException
 {
     public static function create(string $nominativo, string $famiglia, string $msg = ''): SpostaNellaFamigliaError
     {
         return new self("Impossibile spostare {$nominativo} nella famiglia  {$famiglia}. {$msg}");
-    }
-
-    /**
-     * Render the exception into an HTTP response.
-     *
-     * @param  Request  $request
-     * @return Response
-     */
-    public function render($request)
-    {
-
-        $exception = $this;
-
-        return response()->view('errors.sinError', compact('exception'), 500);
     }
 }

--- a/src/App/Sin/Nomadelfia/Exceptions/SpostaNellaFamigliaError.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/SpostaNellaFamigliaError.php
@@ -2,9 +2,6 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-
 class SpostaNellaFamigliaError extends NomadelfiaException
 {
     public static function create(string $nominativo, string $famiglia, string $msg = ''): SpostaNellaFamigliaError

--- a/src/App/Sin/Nomadelfia/Exceptions/StatoDoesNotExists.php
+++ b/src/App/Sin/Nomadelfia/Exceptions/StatoDoesNotExists.php
@@ -2,9 +2,7 @@
 
 namespace App\Nomadelfia\Exceptions;
 
-use InvalidArgumentException;
-
-class StatoDoesNotExists extends InvalidArgumentException
+class StatoDoesNotExists extends NomadelfiaException
 {
     public static function named(string $nome): StatoDoesNotExists
     {


### PR DESCRIPTION
Issue: the excpetion was retunred as 500 with the error " Errore del server. Contattare amministratore (codice errore HTTP 500)`

All the exceptions  of Nomadelfia have been updated to extend a single NomadelfiaException.
The NomadelfiaException has a render method where a custom web page with the informative message is shown.

![image](https://github.com/user-attachments/assets/7dcf5912-2dca-4ca7-b00e-0bbb3984496a)
