### PR TITLE
fix(biblioteca): use popolazione in prestiro instead of all people

### DIFF
--- a/resources/views/biblioteca/libri/prestiti/view.blade.php
+++ b/resources/views/biblioteca/libri/prestiti/view.blade.php
@@ -27,7 +27,7 @@
             <div class="col-md-6">
                 <div class="form-group">
                     <label class="control-label">Cliente</label>
-                    <livewire:search-persona name_input="persona_id" />
+                    <livewire:search-popolazione name_input="persona_id" />
                 </div>
             </div>
             <div class="col-md-6">


### PR DESCRIPTION
In the new prestito, show the popolazione people not all the people.