### PR TITLE
fix(officina): allow note to be  null

### DIFF
--- a/src/App/Sin/Officina/Actions/CreatePrenotazioneAction.php
+++ b/src/App/Sin/Officina/Actions/CreatePrenotazioneAction.php
@@ -20,7 +20,7 @@ final class CreatePrenotazioneAction
         string $ora_partenza,
         string $ora_arrivo,
         Uso $uso,
-        string $note,
+        ?string $note,
         string $destianazione
     ): Prenotazioni {
 

--- a/src/App/Sin/Officina/Controllers/PrenotazioniController.php
+++ b/src/App/Sin/Officina/Controllers/PrenotazioniController.php
@@ -189,7 +189,7 @@ final class PrenotazioniController
             $request->get('ora_par'),
             $request->get('ora_arr'),
             Uso::findOrFail($request->get('uso')),
-            $request->get('note', ''),
+            $request->input('note', ''),
             $request->input('destinazione', '')
         );
 


### PR DESCRIPTION
fix the error 
```
TypeError
App\Officina\Actions\CreatePrenotazioneAction::__invoke(): Argument #9 ($note) must be of type string, null given, called in C:\xampp\htdocs\sin\src\App\Sin\Officina\Controllers\PrenotazioniController.php on line 193
```