### PR TITLE
Fix (laborati): check if file_size is not null - `intl` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The SIN is an Web-based system that permits to manage a series of subsystem (e..
     git clone https://github.com/noma-labs/sin.git
     ```
 
-5. Open the `php.ini` file and enable the PHP extensions (delete the ; character at the beginning of the row): `gd`.
+5. Open the `php.ini` file and enable the PHP extensions (delete the ; character at the beginning of the row): `gd`. and `extension=intl` (required by Number::fileSize)
 
 6. Navigate to the `C:/xampp/htdocs/sin` folder and install the PHP dependencies with Composer (installs the libraries by reading the composer-lock.json file):
     ```

--- a/resources/views/scuola/elaborati/index.blade.php
+++ b/resources/views/scuola/elaborati/index.blade.php
@@ -92,7 +92,9 @@
                             <td>{{ $elaborato->collocazione }}</td>
                             <td>{{ $elaborato->file_mime_type }}</td>
                             <td>
+                                @if ($elaborato->file_size)
                                 {{ Illuminate\Support\Number::fileSize($elaborato->file_size) }}
+                                @endif
                             </td>
                             <td>{{ strtolower($elaborato->note) }}</td>
                             <td>
@@ -120,7 +122,7 @@
                         <div class="card-body">
                             <h5 class="card-title">
                                 {{ $elaborato->titolo }}
-                            </h5>
+                            </h5>s
 
                             {{ strtolower($elaborato->note) }}
 
@@ -153,11 +155,13 @@
                                 >
                                     {{ $elaborato->file_mime_type }}
                                 </span>
-                                <span
-                                    class="badge rounded-pill bg-dark-subtle text-dark-emphasis"
-                                >
-                                    {{ Illuminate\Support\Number::fileSize($elaborato->file_size) }}
-                                </span>
+                                @if ($elaborato->file_size)
+                                    <span
+                                        class="badge rounded-pill bg-dark-subtle text-dark-emphasis"
+                                    >
+                                        {{ Illuminate\Support\Number::fileSize($elaborato->file_size) }}
+                                    </span>
+                                @endif
                             @endif
 
                             <a

--- a/resources/views/scuola/elaborati/index.blade.php
+++ b/resources/views/scuola/elaborati/index.blade.php
@@ -93,7 +93,7 @@
                             <td>{{ $elaborato->file_mime_type }}</td>
                             <td>
                                 @if ($elaborato->file_size)
-                                {{ Illuminate\Support\Number::fileSize($elaborato->file_size) }}
+                                    {{ Illuminate\Support\Number::fileSize($elaborato->file_size) }}
                                 @endif
                             </td>
                             <td>{{ strtolower($elaborato->note) }}</td>
@@ -122,7 +122,7 @@
                         <div class="card-body">
                             <h5 class="card-title">
                                 {{ $elaborato->titolo }}
-                            </h5>s
+                            </h5>
 
                             {{ strtolower($elaborato->note) }}
 


### PR DESCRIPTION
-The `Number::fileSize` requires to enable the `intl` extension. added into the readme.