### PR TITLE
fix(scuola): classeSuccessiva fix php annotation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7567,12 +7567,6 @@ parameters:
 			path: src/App/Sin/Scuola/Models/Anno.php
 
 		-
-			message: '#^Call to an undefined method App\\Scuola\\Models\\ClasseTipo\:\:first\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/App/Sin/Scuola/Models/Classe.php
-
-		-
 			message: '#^Call to an undefined method Illuminate\\Database\\Query\\Builder\:\:withPivot\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/src/App/Sin/Scuola/Models/ClasseTipo.php
+++ b/src/App/Sin/Scuola/Models/ClasseTipo.php
@@ -72,7 +72,6 @@ final class ClasseTipo extends Model
         return $query->where('id', '=', $this->next);
     }
 
-
     public function scopePrescuola($query): self
     {
         return $query->where('ciclo', '=', 'prescuola')->first();

--- a/src/App/Sin/Scuola/Models/ClasseTipo.php
+++ b/src/App/Sin/Scuola/Models/ClasseTipo.php
@@ -7,6 +7,7 @@ namespace App\Scuola\Models;
 use App\Scuola\Exceptions\GeneralException;
 use Carbon\Carbon;
 use Domain\Nomadelfia\Persona\Models\Persona;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
@@ -18,7 +19,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  * @property int $next
  *
  * @method Prescuola()
- * @method ClasseTipo classeSuccessiva()
+ * @method Builder<ClasseTipo> classeSuccessiva()
  * */
 final class ClasseTipo extends Model
 {
@@ -63,10 +64,14 @@ final class ClasseTipo extends Model
         return $this->alunni()->where('data_fine', '=', null);
     }
 
-    public function scopeClasseSuccessiva($query): self
+    /**
+     * @return Builder<ClasseTipo>
+     */
+    public function scopeClasseSuccessiva($query)
     {
         return $query->where('id', '=', $this->next);
     }
+
 
     public function scopePrescuola($query): self
     {


### PR DESCRIPTION
Error:
```
scopeClasseSuccessiva(): Return value must be of type App\Scuola\Models\ClasseTipo, Illuminate\Database\Eloquent\Builder returned {"userId":19,"exception":"[object] (TypeError(code: 0): App\\Scuola\\Models\\ClasseTipo::scopeClasseSuccessiva(): Return value must be of type App\\Scuola\\Models\\ClasseTipo, Illuminate\\Database\\Eloquent\\Builder returned at C:\\xampp\\htdocs\\sin\\src\\App\\Sin\\Scuola\\Models\\ClasseTipo.php:68)
[stacktrace]
``
Fix php annotation to the `classeSuccessiva`