### PR TITLE
feat: show the family from the `ALFA` Enrico table 

### DIFF
--- a/database/factories/PersonaFactory.php
+++ b/database/factories/PersonaFactory.php
@@ -122,4 +122,13 @@ final class PersonaFactory extends Factory
             ];
         });
     }
+
+    public function withIdEnrico(int $id)
+    {
+        return $this->state(function (array $attributes) use ($id) {
+            return [
+                'id_alfa_enrico' => $id,
+            ];
+        });
+    }
 }

--- a/database/migrations/db_nomadelfia/2020_12_18_074135_create_persone_table.up.sql
+++ b/database/migrations/db_nomadelfia/2020_12_18_074135_create_persone_table.up.sql
@@ -6,7 +6,7 @@ CREATE TABLE `persone` (
   `nome` varchar(30) NOT NULL,
   `cognome` varchar(30) NOT NULL,
   `id_arch_pietro` int(10) NOT NULL,
-  `id_alfa_enrico` int(10)  DEFAULT NULL,
+  `id_alfa_enrico` int(10)  DEFAULT NULL COMMENT 'File ALFA di Enrico ricevuto il 15 feb 2023',
   `provincia_nascita` varchar(64) DEFAULT NULL,
   `data_nascita` date NOT NULL,
   `sesso` enum('F','M') NOT NULL,
@@ -24,3 +24,63 @@ CREATE TABLE `persone` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `persone`  ADD UNIQUE KEY `unq_persone_nome_cognome_nascita` (`nome`, `cognome`, `data_nascita`);
+
+
+-- Temporary table added to have the "famiglia" field in the "persone" table
+CREATE TABLE `alfa_enrico_15_feb_23` (
+  `ID` int(10) NOT NULL,
+  `COGNOME` varchar(255) DEFAULT NULL,
+  `NOME` varchar(255) DEFAULT NULL,
+  `ALIAS` varchar(255) DEFAULT NULL,
+  `FOTO` varchar(255) DEFAULT NULL,
+  `S` varchar(255) DEFAULT NULL,
+  `FAMIGLIA` varchar(255) DEFAULT NULL,
+  `NASCITA` date DEFAULT NULL,
+  `COMUNE` varchar(255) DEFAULT NULL,
+  `PROVINCIA` varchar(255) DEFAULT NULL,
+  `REGIONE` varchar(255) DEFAULT NULL,
+  `NAZIONE` varchar(255) DEFAULT NULL,
+  `O` enum('A','E','F','I') DEFAULT NULL,
+  `ENTRATA` date DEFAULT NULL,
+  `POS` varchar(255) DEFAULT NULL,
+  `POSTULA` date DEFAULT NULL,
+  `EFFETT` date DEFAULT NULL,
+  `STATO` varchar(255) DEFAULT NULL,
+  `ORDINATO` date DEFAULT NULL,
+  `MATRIMONIO` date DEFAULT NULL,
+  `LSC` varchar(255) DEFAULT NULL,
+  `BATTESIMO` date DEFAULT NULL,
+  `CRESIMA` date DEFAULT NULL,
+  `USCITA` date DEFAULT NULL,
+  `USC` varchar(255) DEFAULT NULL,
+  `DIMISSIONI` date DEFAULT NULL,
+  `RIENTRO` date DEFAULT NULL,
+  `RIUSCITA` date DEFAULT NULL,
+  `RIENTROS` date DEFAULT NULL,
+  `RIRIUSC` date DEFAULT NULL,
+  `RIENTRO3` date DEFAULT NULL,
+  `RIUSC4` date DEFAULT NULL,
+  `RIENTRO4` date DEFAULT NULL,
+  `DECESSO` date DEFAULT NULL,
+  `FUNERALE` date DEFAULT NULL,
+  `LUOGO` varchar(255) DEFAULT NULL,
+  `SEPOLTURA` date DEFAULT NULL,
+  `CIMITERO` varchar(255) DEFAULT NULL,
+  `LOCALITA` varchar(255) DEFAULT NULL,
+  `MODO` varchar(255) DEFAULT NULL,
+  `CINERARIO` varchar(255) DEFAULT NULL,
+  `NELEN` varchar(255) DEFAULT NULL,
+  `NELEN_FORMAT` varchar(255) DEFAULT NULL COMMENT 'NELEN with trim spaces and numbers and letters inverted',
+  `P` varchar(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+
+ALTER TABLE `alfa_enrico_15_feb_23`
+  ADD PRIMARY KEY (`ID`);
+
+ALTER TABLE `alfa_enrico_15_feb_23`
+  MODIFY `ID` int(10) NOT NULL AUTO_INCREMENT;
+COMMIT;
+
+ALTER TABLE `persone`
+  ADD CONSTRAINT `alf_enrico_feb23_fk` FOREIGN KEY (`id_alfa_enrico`) REFERENCES `alfa_enrico_15_feb_23` (`ID`);
+COMMIT;

--- a/database/seeders/NomadelfiaTableSeeder.php
+++ b/database/seeders/NomadelfiaTableSeeder.php
@@ -13,6 +13,7 @@ use Domain\Nomadelfia\PopolazioneNomadelfia\Actions\EntrataMaggiorenneConFamigli
 use Domain\Nomadelfia\PopolazioneNomadelfia\Actions\EntrataMaggiorenneSingleAction;
 use Domain\Nomadelfia\PopolazioneNomadelfia\Actions\EntrataMinorenneAccoltoAction;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 final class NomadelfiaTableSeeder extends Seeder
 {
@@ -28,8 +29,13 @@ final class NomadelfiaTableSeeder extends Seeder
         $famiglia = Famiglia::factory()->create();
         $now = Carbon::now();
 
-        $capoFam = Persona::factory()->maggiorenne()->maschio()->create();
-        $moglie = Persona::factory()->maggiorenne()->femmina()->create();
+        DB::connection('db_nomadelfia')->insert('INSERT INTO alfa_enrico_15_feb_23 (FAMIGLIA) values (?)', ['MAMMA1 BABBO1']);
+        $last = DB::connection('db_nomadelfia')->select('SELECT LAST_INSERT_ID() as id');
+        $capoFam = Persona::factory()->maggiorenne()->maschio()->withIdEnrico($last[0]->id)->create();
+
+        DB::connection('db_nomadelfia')->insert('INSERT INTO alfa_enrico_15_feb_23 (FAMIGLIA) values (?)', ['MAMMA1 BABBO1']);
+        $last = DB::connection('db_nomadelfia')->select('SELECT LAST_INSERT_ID() as id');
+        $moglie = Persona::factory()->maggiorenne()->femmina()->withIdEnrico($last[0]->id)->create();
 
         $act = app(EntrataMaggiorenneConFamigliaAction::class);
         $act->execute($capoFam, $now, $gruppo);

--- a/resources/views/nomadelfia/persone/show.blade.php
+++ b/resources/views/nomadelfia/persone/show.blade.php
@@ -462,6 +462,13 @@
                     <div class="card-header">Dati Famiglia</div>
                     <div class="card-body">
                         <ul class="list-group list-group-flush">
+                            @if ($famigliaEnrico)
+                                <div class="alert alert-warning" role="alert">
+                                    <strong>ALFA Enrico:</strong>
+                                    {{ Illuminate\Support\Str::headline($famigliaEnrico->famiglia) }}
+                                </div>
+                            @endif
+
                             @if ($famigliaAttuale)
                                 <li class="list-group-item">
                                     <div class="row">

--- a/resources/views/scuola/templates/aggiungiAlunno.blade.php
+++ b/resources/views/scuola/templates/aggiungiAlunno.blade.php
@@ -25,7 +25,7 @@
                     >
                         @foreach ($alunniPossibili as $alunno)
                             <option value="{{ $alunno->id }}">
-                                {{ "(" . Carbon::createFromFormat("Y-m-d", $alunno->data_nascita)->year . ") " . $alunno->nome . " " . $alunno->cognome . " (" . $alunno->nominativo . ")" }}
+                                {{ "(" . Carbon::createFromFormat("Y-m-d", $alunno->data_nascita)->year . ") " . $alunno->nome . " " . $alunno->cognome . " (" . $alunno->nominativo . ")" . " - " . $alunno->famigliaEnrico }}
                             </option>
                         @endforeach
                     </select>

--- a/src/App/Sin/Nomadelfia/Persona/Controllers/PersoneController.php
+++ b/src/App/Sin/Nomadelfia/Persona/Controllers/PersoneController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Nomadelfia\Persona\Controllers;
 
 use Domain\Nomadelfia\Persona\Models\Persona;
+use Illuminate\Support\Facades\DB;
 
 final class PersoneController
 {
@@ -15,8 +16,14 @@ final class PersoneController
         $gruppoAttuale = $persona->gruppofamiliareAttuale();
         $famigliaAttuale = $persona->famigliaAttuale();
 
+        $famigliaEnrico = DB::connection('db_nomadelfia')
+            ->table('alfa_enrico_15_feb_23')
+            ->select('famiglia')
+            ->where('id', $persona->id_alfa_enrico)
+            ->first();
+
         return view('nomadelfia.persone.show',
-            compact('persona', 'posizioneAttuale', 'gruppoAttuale', 'famigliaAttuale'));
+            compact('persona', 'posizioneAttuale', 'gruppoAttuale', 'famigliaAttuale', 'famigliaEnrico'));
     }
 
     public function delete($idPersona)

--- a/src/App/Sin/Scuola/Models/Classe.php
+++ b/src/App/Sin/Scuola/Models/Classe.php
@@ -190,7 +190,8 @@ final class Classe extends Model
 
         }
 
-        $all = Persona::query()->select('persone.id', 'persone.data_nascita', 'persone.nome', 'persone.cognome', 'persone.nominativo')
+        $all = Persona::query()->select('persone.id', 'persone.data_nascita', 'persone.nome', 'persone.cognome', 'persone.nominativo', 'alfa_enrico_15_feb_23.famiglia as famigliaEnrico')
+            ->leftJoin('alfa_enrico_15_feb_23', 'persone.id_alfa_enrico', '=', 'alfa_enrico_15_feb_23.id')
             ->where('persone.data_nascita', '<=', $end)
             ->where('persone.data_nascita', '>=', $start)
             ->orderByRaw('data_nascita ASC, nominativo ASC')


### PR DESCRIPTION
The table `alfa_enrico_15_feb_23` contain a column `FAMIGLIA` with the parents of a person. 
Since the persons are known based on theis son-parent relationship, it is useful to add it.

- add families info into the `add student` action in order to recognize a person based on his family
- add families into the show page of a person

NOTE: this is a temporary solution. It can be remove when the families are recreated into the new table structure.