### PR TITLE
fix(elaborati):  fix and remove the nester folder 

### DIFF
--- a/app/Console/Commands/MoveCoverElaboratiCommand.php
+++ b/app/Console/Commands/MoveCoverElaboratiCommand.php
@@ -11,9 +11,9 @@ use RuntimeException;
 
 final class MoveCoverElaboratiCommand extends Command
 {
-    protected $signature = 'elaborati:move';
+    protected $signature = 'elaborati:move-cover';
 
-    protected $description = 'Move elaborati files to storage/app/original/elaborati and rename them.';
+    protected $description = 'Move cover elaborati files to storage/app/preview/elaborati and rename them.';
 
     public function handle(): void
     {

--- a/app/Console/Commands/MoveElaboratiFilesCommand.php
+++ b/app/Console/Commands/MoveElaboratiFilesCommand.php
@@ -14,7 +14,7 @@ final class MoveElaboratiFilesCommand extends Command
 
     protected $description = 'Move elaborati files from nested folders to flat structure and update DB paths';
 
-    public function handle()
+    public function handle(): void
     {
         $disk = Storage::disk('media_originals');
         $years = $disk->directories('elaborati');
@@ -38,7 +38,7 @@ final class MoveElaboratiFilesCommand extends Command
                     }
 
                     // Update DB if needed
-                    $updated = Elaborato::where('file_path', $filePath)
+                    $updated = Elaborato::query()->where('file_path', $filePath)
                         ->orWhere('file_path', 'like', "%$filePath")
                         ->update(['file_path' => $newPath]);
 
@@ -57,6 +57,6 @@ final class MoveElaboratiFilesCommand extends Command
 
         $this->info('All files moved and DB updated.');
 
-        return 0;
+        return;
     }
 }

--- a/app/Console/Commands/MoveElaboratiFilesCommand.php
+++ b/app/Console/Commands/MoveElaboratiFilesCommand.php
@@ -57,6 +57,5 @@ final class MoveElaboratiFilesCommand extends Command
 
         $this->info('All files moved and DB updated.');
 
-        return;
     }
 }

--- a/app/Console/Commands/MoveElaboratiFilesCommand.php
+++ b/app/Console/Commands/MoveElaboratiFilesCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Scuola\Models\Elaborato;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+final class MoveElaboratiFilesCommand extends Command
+{
+    protected $signature = 'elaborati:move-files';
+
+    protected $description = 'Move elaborati files from nested folders to flat structure and update DB paths';
+
+    public function handle()
+    {
+        $disk = Storage::disk('media_originals');
+        $years = $disk->directories('elaborati');
+
+        foreach ($years as $yearDir) {
+            $nestedDirs = $disk->directories($yearDir);
+
+            foreach ($nestedDirs as $nestedDir) {
+                $files = $disk->files($nestedDir);
+
+                foreach ($files as $filePath) {
+                    $fileName = basename((string) $filePath);
+                    $newPath = $yearDir.'/'.$fileName;
+
+                    // Move the file if it doesn't already exist at the destination
+                    if (! $disk->exists($newPath)) {
+                        $disk->move($filePath, $newPath);
+                        $this->info("Moved: $filePath -> $newPath");
+                    } else {
+                        $this->warn("Skipped (already exists): $newPath");
+                    }
+
+                    // Update DB if needed
+                    $updated = Elaborato::where('file_path', $filePath)
+                        ->orWhere('file_path', 'like', "%$filePath")
+                        ->update(['file_path' => $newPath]);
+
+                    if ($updated) {
+                        $this->info("Updated DB for: $newPath");
+                    }
+                }
+
+                // Optionally, remove the now-empty nested directory
+                if (empty($disk->files($nestedDir))) {
+                    $disk->deleteDirectory($nestedDir);
+                    $this->info("Deleted empty directory: $nestedDir");
+                }
+            }
+        }
+
+        $this->info('All files moved and DB updated.');
+
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -8,6 +8,7 @@ use App\Console\Commands\CreateDatabaseCommand;
 use App\Console\Commands\ExifExtractCommand;
 use App\Console\Commands\ExifJsonImportCommand;
 use App\Console\Commands\MoveCoverElaboratiCommand;
+use App\Console\Commands\MoveElaboratiFilesCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -23,6 +24,7 @@ final class Kernel extends ConsoleKernel
         ExifExtractCommand::class,
         ExifJsonImportCommand::class,
         MoveCoverElaboratiCommand::class,
+        MoveElaboratiFilesCommand::class,
     ];
 
     /**

--- a/app/Http/Scuola/Traits/StoresElaboratoFile.php
+++ b/app/Http/Scuola/Traits/StoresElaboratoFile.php
@@ -7,14 +7,10 @@ namespace App\Scuola\Traits;
 use App\Scuola\DataTransferObjects\AnnoScolastico;
 use Exception;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 trait StoresElaboratoFile
 {
-    /**
-     * Store the elaborato file and return its storage path.
-     */
     protected function storeElaboratoFile(
         UploadedFile $file,
         AnnoScolastico $as,
@@ -23,10 +19,11 @@ trait StoresElaboratoFile
     ): string {
         $titleSlug = Str::slug($titolo);
 
-        $destinationPath = "elaborati/{$as->endYear}_{$collocazione}_{$titleSlug}.{$file->getClientOriginalExtension()}";
-        if (Storage::disk('media_originals')->put($destinationPath, $file)) {
-            return $destinationPath;
+        $destinationPath = $file->storeAs("elaborati/{$as->endYear}", "{$collocazione}_{$titleSlug}.{$file->getClientOriginalExtension()}", 'media_originals');
+        if (! $destinationPath) {
+            throw new Exception('Error storing to disk Request', 1);
         }
-        throw new Exception('Error storing into disk');
+
+        return $destinationPath;
     }
 }


### PR DESCRIPTION
- fix the controler to store the elaborati without the nested fodler
- Add a command `elaborati:move-files` to remove the subfolder and update the db accordingly

before
```
2025
   SPA00_la-natura
       SPA00ò-la-natura.pdf
```

after
```
2025
       SPA00ò-la-natura.pdf
```