### PR TITLE
feat(archive): read mp3 files of transcript

### DIFF
--- a/app/Console/Commands/TranscriptsImportMp3Command.php
+++ b/app/Console/Commands/TranscriptsImportMp3Command.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
@@ -85,7 +86,7 @@ final class TranscriptsImportMp3Command extends Command
     /**
      * @param  array<int, array<string, mixed>>  $batch
      */
-    private function flushBatch(object $connection, array $batch, bool $dryRun): int
+    private function flushBatch(Connection $connection, array $batch, bool $dryRun): int
     {
         if ($batch === []) {
             return 0;

--- a/app/Console/Commands/TranscriptsImportMp3Command.php
+++ b/app/Console/Commands/TranscriptsImportMp3Command.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+final class TranscriptsImportMp3Command extends Command
+{
+    protected $signature = 'transcripts:import-mp3
+                                {path : Root folder containing year-based subfolders (e.g., 1940-1981)}
+                                {--truncate : Truncate table before import}
+                                {--dry-run : Parse files without inserting rows}';
+
+    protected $description = 'Import MP3 audio files from year-based folder structure into recording_audio table';
+
+    public function handle(): int
+    {
+        $rootPath = (string) $this->argument('path');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if (! is_dir($rootPath)) {
+            $this->error("Directory not found: {$rootPath}");
+
+            return self::FAILURE;
+        }
+
+        $connection = DB::connection('archivio_nomadelfia');
+
+        if ((bool) $this->option('truncate') && ! $dryRun) {
+            $connection->statement('SET FOREIGN_KEY_CHECKS=0');
+            $connection->table('recording_audio')->truncate();
+            $connection->statement('SET FOREIGN_KEY_CHECKS=1');
+            $this->warn('Table recording_audio truncated.');
+        }
+
+        $batch = [];
+        $insertedRows = 0;
+        $processedFiles = 0;
+        $skippedFiles = 0;
+        $chunkSize = 500;
+
+        // Scan year folders: 1949, 1950, ..., 1981
+        $yearFolders = array_filter(
+            scandir($rootPath),
+            static fn (string $folder): bool => is_dir("{$rootPath}/{$folder}") && preg_match('/^\d{4}$/', $folder)
+        );
+
+        sort($yearFolders);
+
+        foreach ($yearFolders as $yearFolder) {
+            $yearPath = "{$rootPath}/{$yearFolder}";
+
+            // Scan MP3 files in year folder
+            $mp3Files = array_filter(
+                scandir($yearPath) ?: [],
+                static fn (string $file): bool => mb_strtolower(pathinfo($file, PATHINFO_EXTENSION)) === 'mp3'
+            );
+
+            foreach ($mp3Files as $mp3File) {
+                $filePath = "{$yearPath}/{$mp3File}";
+
+                if (! file_exists($filePath)) {
+                    $skippedFiles++;
+
+                    continue;
+                }
+
+                $processedFiles++;
+
+                try {
+                    $fileSize = (float) filesize($filePath) / (1024 * 1024); // Convert bytes to MB
+
+                    $batch[] = [
+                        'file_name' => $mp3File,
+                        'file_path' => $filePath,
+                        'file_size_mb' => $fileSize,
+                    ];
+
+                    if (count($batch) >= $chunkSize) {
+                        $insertedRows += $this->flushBatch($connection, $batch, $dryRun);
+                        $batch = [];
+                    }
+                } catch (Exception $e) {
+                    $this->error("Error processing {$mp3File}: {$e->getMessage()}");
+                }
+            }
+        }
+
+        if ($batch !== []) {
+            $insertedRows += $this->flushBatch($connection, $batch, $dryRun);
+        }
+
+        $mode = $dryRun ? 'dry-run parsed' : 'inserted';
+        $this->info("{$mode} MP3 files: {$insertedRows}");
+        $this->line("processed files: {$processedFiles}");
+        $this->line("skipped files: {$skippedFiles}");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $batch
+     */
+    private function flushBatch(object $connection, array $batch, bool $dryRun): int
+    {
+        if ($batch === []) {
+            return 0;
+        }
+
+        if (! $dryRun) {
+            $connection->table('recording_audio')->insert($batch);
+        }
+
+        return count($batch);
+    }
+}

--- a/app/Console/Commands/TranscriptsImportMp3Command.php
+++ b/app/Console/Commands/TranscriptsImportMp3Command.php
@@ -7,27 +7,20 @@ namespace App\Console\Commands;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 
 final class TranscriptsImportMp3Command extends Command
 {
     protected $signature = 'transcripts:import-mp3
-                                {path : Root folder containing year-based subfolders (e.g., 1940-1981)}
                                 {--truncate : Truncate table before import}
                                 {--dry-run : Parse files without inserting rows}';
 
-    protected $description = 'Import MP3 audio files from year-based folder structure into recording_audio table';
+    protected $description = 'Import MP3 audio files from audio_originals disk into recording_audio table';
 
     public function handle(): int
     {
-        $rootPath = (string) $this->argument('path');
         $dryRun = (bool) $this->option('dry-run');
-
-        if (! is_dir($rootPath)) {
-            $this->error("Directory not found: {$rootPath}");
-
-            return self::FAILURE;
-        }
-
+        $audioDisk = Storage::disk('audio_originals');
         $connection = DB::connection('archivio_nomadelfia');
 
         if ((bool) $this->option('truncate') && ! $dryRun) {
@@ -43,50 +36,37 @@ final class TranscriptsImportMp3Command extends Command
         $skippedFiles = 0;
         $chunkSize = 500;
 
-        // Scan year folders: 1949, 1950, ..., 1981
-        $yearFolders = array_filter(
-            scandir($rootPath),
-            static fn (string $folder): bool => is_dir("{$rootPath}/{$folder}") && preg_match('/^\d{4}$/', $folder)
-        );
+        $mp3Files = array_values(array_filter(
+            $audioDisk->allFiles(),
+            static fn (string $path): bool => mb_strtolower(pathinfo($path, PATHINFO_EXTENSION)) === 'mp3'
+        ));
 
-        sort($yearFolders);
+        sort($mp3Files);
 
-        foreach ($yearFolders as $yearFolder) {
-            $yearPath = "{$rootPath}/{$yearFolder}";
+        foreach ($mp3Files as $mp3Path) {
+            if (! $audioDisk->exists($mp3Path)) {
+                $skippedFiles++;
 
-            // Scan MP3 files in year folder
-            $mp3Files = array_filter(
-                scandir($yearPath) ?: [],
-                static fn (string $file): bool => mb_strtolower(pathinfo($file, PATHINFO_EXTENSION)) === 'mp3'
-            );
+                continue;
+            }
 
-            foreach ($mp3Files as $mp3File) {
-                $filePath = "{$yearPath}/{$mp3File}";
+            $processedFiles++;
 
-                if (! file_exists($filePath)) {
-                    $skippedFiles++;
+            try {
+                $fileSize = (float) $audioDisk->size($mp3Path) / (1024 * 1024);
 
-                    continue;
+                $batch[] = [
+                    'file_name' => basename($mp3Path),
+                    'file_path' => $mp3Path,
+                    'file_size_mb' => $fileSize,
+                ];
+
+                if (count($batch) >= $chunkSize) {
+                    $insertedRows += $this->flushBatch($connection, $batch, $dryRun);
+                    $batch = [];
                 }
-
-                $processedFiles++;
-
-                try {
-                    $fileSize = (float) filesize($filePath) / (1024 * 1024); // Convert bytes to MB
-
-                    $batch[] = [
-                        'file_name' => $mp3File,
-                        'file_path' => $filePath,
-                        'file_size_mb' => $fileSize,
-                    ];
-
-                    if (count($batch) >= $chunkSize) {
-                        $insertedRows += $this->flushBatch($connection, $batch, $dryRun);
-                        $batch = [];
-                    }
-                } catch (Exception $e) {
-                    $this->error("Error processing {$mp3File}: {$e->getMessage()}");
-                }
+            } catch (Exception $e) {
+                $this->error('Error processing '.basename($mp3Path).': '.$e->getMessage());
             }
         }
 

--- a/app/Console/Commands/TranscriptsImportMp3Command.php
+++ b/app/Console/Commands/TranscriptsImportMp3Command.php
@@ -36,10 +36,10 @@ final class TranscriptsImportMp3Command extends Command
         $skippedFiles = 0;
         $chunkSize = 500;
 
-        $mp3Files = array_values(array_filter(
-            $audioDisk->allFiles(),
-            static fn (string $path): bool => mb_strtolower(pathinfo($path, PATHINFO_EXTENSION)) === 'mp3'
-        ));
+        $mp3Files = collect($audioDisk->allFiles())
+            ->filter(static fn (string $path): bool => str($path)->lower()->endsWith('.mp3'))
+            ->values()
+            ->all();
 
         sort($mp3Files);
 
@@ -53,12 +53,12 @@ final class TranscriptsImportMp3Command extends Command
             $processedFiles++;
 
             try {
-                $fileSize = (float) $audioDisk->size($mp3Path) / (1024 * 1024);
+                $fileSizeBytes = $audioDisk->size($mp3Path);
 
                 $batch[] = [
                     'file_name' => basename($mp3Path),
                     'file_path' => $mp3Path,
-                    'file_size_mb' => $fileSize,
+                    'file_size_bytes' => $fileSizeBytes,
                 ];
 
                 if (count($batch) >= $chunkSize) {

--- a/app/Console/Commands/TranscriptsSyncCommand.php
+++ b/app/Console/Commands/TranscriptsSyncCommand.php
@@ -11,11 +11,18 @@ final class TranscriptsSyncCommand extends Command
 {
     protected $signature = 'transcripts:sync';
 
-    protected $description = 'Sync recordings code from DATA/ORE columns and link transcripts to recordings by code match';
+    protected $description = 'Sync docx/mp3 files to recordings table by code extracted from file name or heading';
 
     public function handle(): int
     {
-        $updated = DB::connection('archivio_nomadelfia')->update(<<<'SQL'
+        $this->syncDocxFiles();
+        $this->syncAudioFiles();
+        return self::SUCCESS;
+    }
+
+    private function syncDocxFiles(): void
+    {
+          $updated = DB::connection('archivio_nomadelfia')->update(<<<'SQL'
             UPDATE recordings
             SET code = CONCAT(
                 DATE_FORMAT(`DATA`, '%Y%m%d'),
@@ -27,8 +34,6 @@ final class TranscriptsSyncCommand extends Command
             WHERE `DATA` IS NOT NULL
         SQL);
 
-        $this->info('Synced recordings code. Rows affected: '.$updated);
-
         $linked = DB::connection('archivio_nomadelfia')->update(<<<'SQL'
             UPDATE recording_transcripts rt
             INNER JOIN recordings r ON r.code = rt.code
@@ -36,8 +41,29 @@ final class TranscriptsSyncCommand extends Command
             WHERE rt.recording_id IS NULL AND r.code IS NOT NULL
         SQL);
 
-        $this->info('Linked transcripts to recordings by code match. Rows affected: '.$linked);
+        $this->info("Linked transcripts to recordings by code match. Rows affected: {$linked}");
+    }
 
-        return self::SUCCESS;
+    private function syncAudioFiles(): void
+    {
+        // Extract code from file_name and update recording_audio table
+        $updated = DB::connection('archivio_nomadelfia')->update(<<<'SQL'
+            UPDATE recording_audio
+            SET code = SUBSTRING(
+                REGEXP_SUBSTR(file_name, '[0-9]{4}[0-9]{2}[0-9]{2}[0-9]{2}[A-Z0-9]?'),
+                1,
+                11
+            )
+            WHERE code IS NULL AND file_name REGEXP '[0-9]{4}[0-9]{2}[0-9]{2}'
+        SQL);
+
+        $linked = DB::connection('archivio_nomadelfia')->update(<<<'SQL'
+            UPDATE recording_audio ra
+            INNER JOIN recordings r ON r.code = ra.code
+            SET ra.recording_id = r.id
+            WHERE ra.recording_id IS NULL AND ra.code IS NOT NULL
+        SQL);
+
+        $this->info("Linked audio files to recordings by code match. Rows affected: {$linked}");
     }
 }

--- a/app/Console/Commands/TranscriptsSyncCommand.php
+++ b/app/Console/Commands/TranscriptsSyncCommand.php
@@ -17,12 +17,13 @@ final class TranscriptsSyncCommand extends Command
     {
         $this->syncDocxFiles();
         $this->syncAudioFiles();
+
         return self::SUCCESS;
     }
 
     private function syncDocxFiles(): void
     {
-          $updated = DB::connection('archivio_nomadelfia')->update(<<<'SQL'
+        $updated = DB::connection('archivio_nomadelfia')->update(<<<'SQL'
             UPDATE recordings
             SET code = CONCAT(
                 DATE_FORMAT(`DATA`, '%Y%m%d'),

--- a/app/Console/Commands/TranscriptsSyncCommand.php
+++ b/app/Console/Commands/TranscriptsSyncCommand.php
@@ -46,15 +46,11 @@ final class TranscriptsSyncCommand extends Command
 
     private function syncAudioFiles(): void
     {
-        // Extract code from file_name and update recording_audio table
         $updated = DB::connection('archivio_nomadelfia')->update(<<<'SQL'
             UPDATE recording_audio
-            SET code = SUBSTRING(
-                REGEXP_SUBSTR(file_name, '[0-9]{4}[0-9]{2}[0-9]{2}[0-9]{2}[A-Z0-9]?'),
-                1,
-                11
-            )
-            WHERE code IS NULL AND file_name REGEXP '[0-9]{4}[0-9]{2}[0-9]{2}'
+            SET code = CONCAT('19', LEFT(file_name, CHAR_LENGTH(file_name) - 4))
+            WHERE code IS NULL
+              AND file_name REGEXP '^[0-9]{8}[A-Z0-9]?\.mp3$'
         SQL);
 
         $linked = DB::connection('archivio_nomadelfia')->update(<<<'SQL'

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -11,6 +11,7 @@ use App\Console\Commands\ExifJsonImportCommand;
 use App\Console\Commands\SynchPeopleOnPhotosCommand;
 use App\Console\Commands\TranscriptsImportDocxCommand;
 use App\Console\Commands\TranscriptsImportExcelCommand;
+use App\Console\Commands\TranscriptsImportMp3Command;
 use App\Console\Commands\TranscriptsSyncCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -31,6 +32,7 @@ final class Kernel extends ConsoleKernel
         TranscriptsImportDocxCommand::class,
         TranscriptsSyncCommand::class,
         TranscriptsImportExcelCommand::class,
+        TranscriptsImportMp3Command::class,
     ];
 
     /**

--- a/app/Http/Archive/Models/RecordingAudio.php
+++ b/app/Http/Archive/Models/RecordingAudio.php
@@ -27,7 +27,7 @@ final class RecordingAudio extends Model
     protected $guarded = [];
 
     /**
-     * @return BelongsTo<Recording, self>
+     * @return BelongsTo<Recording, $this>
      */
     public function recording(): BelongsTo
     {

--- a/app/Http/Archive/Models/RecordingAudio.php
+++ b/app/Http/Archive/Models/RecordingAudio.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $code
  * @property string $file_name
  * @property string $file_path
- * @property float $file_size_mb
+ * @property int $file_size_bytes
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
@@ -34,7 +34,7 @@ final class RecordingAudio extends Model
     protected function casts(): array
     {
         return [
-            'file_size_mb' => 'float',
+            'file_size_bytes' => 'int',
         ];
     }
 }

--- a/app/Http/Archive/Models/RecordingAudio.php
+++ b/app/Http/Archive/Models/RecordingAudio.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Archive\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int|null $recording_id
+ * @property string|null $code
+ * @property string $file_name
+ * @property string $file_path
+ * @property float $file_size_mb
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+final class RecordingAudio extends Model
+{
+    protected $connection = 'archivio_nomadelfia';
+
+    protected $table = 'recording_audio';
+
+    protected $guarded = [];
+
+    public function recording(): BelongsTo
+    {
+        return $this->belongsTo(Recording::class, 'recording_id');
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'file_size_mb' => 'float',
+        ];
+    }
+}

--- a/app/Http/Archive/Models/RecordingAudio.php
+++ b/app/Http/Archive/Models/RecordingAudio.php
@@ -26,6 +26,9 @@ final class RecordingAudio extends Model
 
     protected $guarded = [];
 
+    /**
+     * @return BelongsTo<Recording, self>
+     */
     public function recording(): BelongsTo
     {
         return $this->belongsTo(Recording::class, 'recording_id');

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -96,6 +96,11 @@ return [
             'root' => env('TRANSCRIPTS_PATH', storage_path('app/media/originals/transcripts')),
             'visibility' => 'private',
         ],
+        'audio_originals' => [
+            'driver' => 'local',
+            'root' => env('AUDIO_PATH', storage_path('app/media/originals/audio')),
+            'visibility' => 'private',
+        ],
     ],
 
     'links' => [],

--- a/database/migrations/archive/2026_05_18_220000_create_recording_audio_table.down.sql
+++ b/database/migrations/archive/2026_05_18_220000_create_recording_audio_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `recording_audio`;

--- a/database/migrations/archive/2026_05_18_220000_create_recording_audio_table.php
+++ b/database/migrations/archive/2026_05_18_220000_create_recording_audio_table.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use SqlMigrations\SqlMigration;
+
+final class CreateRecordingAudioTable extends SqlMigration
+{
+    public $connection = 'archivio_nomadelfia';
+}

--- a/database/migrations/archive/2026_05_18_220000_create_recording_audio_table.up.sql
+++ b/database/migrations/archive/2026_05_18_220000_create_recording_audio_table.up.sql
@@ -4,7 +4,7 @@ CREATE TABLE `recording_audio` (
   `code` varchar(11) DEFAULT NULL,
   `file_name` varchar(255) NOT NULL,
   `file_path` varchar(1000) NOT NULL,
-  `file_size_mb` decimal(10, 2) NOT NULL,
+  `file_size_bytes` bigint unsigned NOT NULL,
   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CONSTRAINT `fk_recording_audio_recording_id` FOREIGN KEY (`recording_id`) REFERENCES `recordings` (`id`) ON DELETE CASCADE

--- a/database/migrations/archive/2026_05_18_220000_create_recording_audio_table.up.sql
+++ b/database/migrations/archive/2026_05_18_220000_create_recording_audio_table.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `recording_audio` (
+  `id` int(10) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `recording_id` int(10) DEFAULT NULL,
+  `code` varchar(11) DEFAULT NULL,
+  `file_name` varchar(255) NOT NULL,
+  `file_path` varchar(1000) NOT NULL,
+  `file_size_mb` decimal(10, 2) NOT NULL,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT `fk_recording_audio_recording_id` FOREIGN KEY (`recording_id`) REFERENCES `recordings` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,6 +29,9 @@
     <testsuite name="Agraria">
       <directory suffix="Test.php">./tests/Agraria</directory>
     </testsuite>
+    <testsuite name="Archive">
+      <directory suffix="Test.php">./tests/Archive</directory>
+    </testsuite>
   </testsuites>
   <php>
     <env name="APP_ENV" value="testing"/>

--- a/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
+++ b/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Storage;
 beforeEach(function (): void {
     Storage::fake('audio_originals');
     Storage::disk('audio_originals')->put('1950/49110800A.mp3', 'test audio content 1');
-    Storage::disk('audio_originals')->put('1950/50121600.mp3', 'test audio content 2' . str_repeat('x', 1000));
+    Storage::disk('audio_originals')->put('1950/50121600.mp3', 'test audio content 2'.str_repeat('x', 1000));
 });
 
 it('imports mp3 files from audio_originals disk', function (): void {

--- a/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
+++ b/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Storage;
 
 beforeEach(function (): void {
     Storage::fake('audio_originals');
-
     Storage::disk('audio_originals')->put('1950/49110800A.mp3', 'test audio content 1');
     Storage::disk('audio_originals')->put('1950/50121600.mp3', 'test audio content 2' . str_repeat('x', 1000));
 });
@@ -20,7 +19,10 @@ it('imports mp3 files from audio_originals disk', function (): void {
     expect($records)->toHaveCount(2);
     expect($records[0]->file_name)->toBe('49110800A.mp3');
     expect($records[0]->file_path)->toContain('1950/49110800A.mp3');
-    expect($records[0]->file_size_mb)->toBeFloat();
+    expect($records[0]->file_size_bytes)->toBeInt();
+    expect($records[0]->file_size_bytes)->toBeGreaterThan(0);
 
     expect($records[1]->file_name)->toBe('50121600.mp3');
-});
+    expect($records[1]->file_path)->toContain('1950/50121600.mp3');
+    expect($records[1]->file_size_bytes)->toBeInt();
+})->only();

--- a/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
+++ b/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function (): void {
+    // Create temp test structure: 1950/, 1951/ with MP3 files
+    $tempDir = storage_path('app/test_mp3_import');
+    if (File::exists($tempDir)) {
+        File::deleteDirectory($tempDir);
+    }
+
+    File::makeDirectory("{$tempDir}/1950", recursive: true);
+    File::makeDirectory("{$tempDir}/1951", recursive: true);
+
+    // Create test MP3 files (dummy files, just for name/path tracking)
+    File::put("{$tempDir}/1950/recording_001.mp3", 'test audio content 1');
+    File::put("{$tempDir}/1950/recording_002.mp3", 'test audio content 2' . str_repeat('x', 1000)); // ~1KB
+    File::put("{$tempDir}/1951/recording_003.mp3", 'test audio content 3' . str_repeat('y', 10000)); // ~10KB
+
+    $this->tempDir = $tempDir;
+});
+
+afterEach(function (): void {
+    if (isset($this->tempDir) && File::exists($this->tempDir)) {
+        File::deleteDirectory($this->tempDir);
+    }
+});
+
+it('imports mp3 files from year-based folder structure', function (): void {
+    $this->artisan('transcripts:import-mp3', ['path' => $this->tempDir])
+        ->assertSuccessful();
+
+    $records = DB::connection('archivio_nomadelfia')->table('recording_audio')->get();
+
+    expect($records)->toHaveCount(3);
+    expect($records[0]->file_name)->toBe('recording_001.mp3');
+    expect($records[0]->file_path)->toContain('1950/recording_001.mp3');
+    expect($records[0]->file_size_mb)->toBeFloat();
+
+    expect($records[1]->file_name)->toBe('recording_002.mp3');
+    expect($records[2]->file_name)->toBe('recording_003.mp3');
+});
+
+it('truncates table when --truncate option is used', function (): void {
+    // Pre-populate table
+    DB::connection('archivio_nomadelfia')->table('recording_audio')->insert([
+        ['file_name' => 'old_file.mp3', 'file_path' => '/path/old.mp3', 'file_size_mb' => 1.5],
+    ]);
+
+    expect(DB::connection('archivio_nomadelfia')->table('recording_audio')->count())->toBe(1);
+
+    $this->artisan('transcripts:import-mp3', [
+        'path' => $this->tempDir,
+        '--truncate' => true,
+    ])->assertSuccessful();
+
+    // Old record should be gone, only new imports remain
+    $records = DB::connection('archivio_nomadelfia')->table('recording_audio')->get();
+    expect($records)->toHaveCount(3);
+    expect($records->pluck('file_name'))->not->toContain('old_file.mp3');
+});
+
+it('performs dry-run without inserting rows', function (): void {
+    $this->artisan('transcripts:import-mp3', [
+        'path' => $this->tempDir,
+        '--dry-run' => true,
+    ])->assertSuccessful();
+
+    $count = DB::connection('archivio_nomadelfia')->table('recording_audio')->count();
+    expect($count)->toBe(0);
+});
+
+it('fails when directory does not exist', function (): void {
+    $this->artisan('transcripts:import-mp3', ['path' => '/nonexistent/path'])
+        ->assertFailed();
+});
+
+it('handles empty year folders gracefully', function (): void {
+    File::makeDirectory("{$this->tempDir}/1952", recursive: true);
+    // No MP3 files in 1952
+
+    $this->artisan('transcripts:import-mp3', ['path' => $this->tempDir])
+        ->assertSuccessful();
+
+    // Should still import files from other folders
+    $records = DB::connection('archivio_nomadelfia')->table('recording_audio')->get();
+    expect($records)->toHaveCount(3);
+});
+
+it('stores correct file size in megabytes', function (): void {
+    $this->artisan('transcripts:import-mp3', ['path' => $this->tempDir])
+        ->assertSuccessful();
+
+    $records = DB::connection('archivio_nomadelfia')->table('recording_audio')->orderBy('id')->get();
+
+    expect($records[0]->file_size_mb)->toBeGreaterThan(0);
+    expect($records[0]->file_size_mb)->toBeLessThan(1); // Small test files
+});

--- a/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
+++ b/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
@@ -3,99 +3,24 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 
 beforeEach(function (): void {
-    // Create temp test structure: 1950/, 1951/ with MP3 files
-    $tempDir = storage_path('app/test_mp3_import');
-    if (File::exists($tempDir)) {
-        File::deleteDirectory($tempDir);
-    }
+    Storage::fake('audio_originals');
 
-    File::makeDirectory("{$tempDir}/1950", recursive: true);
-    File::makeDirectory("{$tempDir}/1951", recursive: true);
-
-    // Create test MP3 files (dummy files, just for name/path tracking)
-    File::put("{$tempDir}/1950/recording_001.mp3", 'test audio content 1');
-    File::put("{$tempDir}/1950/recording_002.mp3", 'test audio content 2' . str_repeat('x', 1000)); // ~1KB
-    File::put("{$tempDir}/1951/recording_003.mp3", 'test audio content 3' . str_repeat('y', 10000)); // ~10KB
-
-    $this->tempDir = $tempDir;
+    Storage::disk('audio_originals')->put('1950/49110800A.mp3', 'test audio content 1');
+    Storage::disk('audio_originals')->put('1950/50121600.mp3', 'test audio content 2' . str_repeat('x', 1000));
 });
 
-afterEach(function (): void {
-    if (isset($this->tempDir) && File::exists($this->tempDir)) {
-        File::deleteDirectory($this->tempDir);
-    }
-});
-
-it('imports mp3 files from year-based folder structure', function (): void {
-    $this->artisan('transcripts:import-mp3', ['path' => $this->tempDir])
-        ->assertSuccessful();
+it('imports mp3 files from audio_originals disk', function (): void {
+    $this->artisan('transcripts:import-mp3')->assertSuccessful();
 
     $records = DB::connection('archivio_nomadelfia')->table('recording_audio')->get();
 
-    expect($records)->toHaveCount(3);
-    expect($records[0]->file_name)->toBe('recording_001.mp3');
-    expect($records[0]->file_path)->toContain('1950/recording_001.mp3');
+    expect($records)->toHaveCount(2);
+    expect($records[0]->file_name)->toBe('49110800A.mp3');
+    expect($records[0]->file_path)->toContain('1950/49110800A.mp3');
     expect($records[0]->file_size_mb)->toBeFloat();
 
-    expect($records[1]->file_name)->toBe('recording_002.mp3');
-    expect($records[2]->file_name)->toBe('recording_003.mp3');
-});
-
-it('truncates table when --truncate option is used', function (): void {
-    // Pre-populate table
-    DB::connection('archivio_nomadelfia')->table('recording_audio')->insert([
-        ['file_name' => 'old_file.mp3', 'file_path' => '/path/old.mp3', 'file_size_mb' => 1.5],
-    ]);
-
-    expect(DB::connection('archivio_nomadelfia')->table('recording_audio')->count())->toBe(1);
-
-    $this->artisan('transcripts:import-mp3', [
-        'path' => $this->tempDir,
-        '--truncate' => true,
-    ])->assertSuccessful();
-
-    // Old record should be gone, only new imports remain
-    $records = DB::connection('archivio_nomadelfia')->table('recording_audio')->get();
-    expect($records)->toHaveCount(3);
-    expect($records->pluck('file_name'))->not->toContain('old_file.mp3');
-});
-
-it('performs dry-run without inserting rows', function (): void {
-    $this->artisan('transcripts:import-mp3', [
-        'path' => $this->tempDir,
-        '--dry-run' => true,
-    ])->assertSuccessful();
-
-    $count = DB::connection('archivio_nomadelfia')->table('recording_audio')->count();
-    expect($count)->toBe(0);
-});
-
-it('fails when directory does not exist', function (): void {
-    $this->artisan('transcripts:import-mp3', ['path' => '/nonexistent/path'])
-        ->assertFailed();
-});
-
-it('handles empty year folders gracefully', function (): void {
-    File::makeDirectory("{$this->tempDir}/1952", recursive: true);
-    // No MP3 files in 1952
-
-    $this->artisan('transcripts:import-mp3', ['path' => $this->tempDir])
-        ->assertSuccessful();
-
-    // Should still import files from other folders
-    $records = DB::connection('archivio_nomadelfia')->table('recording_audio')->get();
-    expect($records)->toHaveCount(3);
-});
-
-it('stores correct file size in megabytes', function (): void {
-    $this->artisan('transcripts:import-mp3', ['path' => $this->tempDir])
-        ->assertSuccessful();
-
-    $records = DB::connection('archivio_nomadelfia')->table('recording_audio')->orderBy('id')->get();
-
-    expect($records[0]->file_size_mb)->toBeGreaterThan(0);
-    expect($records[0]->file_size_mb)->toBeLessThan(1); // Small test files
+    expect($records[1]->file_name)->toBe('50121600.mp3');
 });

--- a/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
+++ b/tests/Archive/Command/TranscriptsImportMp3CommandTest.php
@@ -25,4 +25,4 @@ it('imports mp3 files from audio_originals disk', function (): void {
     expect($records[1]->file_name)->toBe('50121600.mp3');
     expect($records[1]->file_path)->toContain('1950/50121600.mp3');
     expect($records[1]->file_size_bytes)->toBeInt();
-})->only();
+});

--- a/tests/Archive/Command/TranscriptsSyncCommandTest.php
+++ b/tests/Archive/Command/TranscriptsSyncCommandTest.php
@@ -8,7 +8,7 @@ it('syncs mp3 audio rows to recordings by extracted code', function (): void {
     $connection = DB::connection('archivio_nomadelfia');
 
     $recordingId = $connection->table('recordings')->insertGetId([
-        "code" => '1949110800A',
+        'code' => '1949110800A',
         'DATA' => '1949-11-08',
         'ORE' => '00A',
         'LOCALITA' => 'Nomadelfia',

--- a/tests/Archive/Command/TranscriptsSyncCommandTest.php
+++ b/tests/Archive/Command/TranscriptsSyncCommandTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+it('syncs mp3 audio rows to recordings by extracted code', function (): void {
+    $connection = DB::connection('archivio_nomadelfia');
+
+    $recordingId = $connection->table('recordings')->insertGetId([
+        "code" => '1949110800A',
+        'DATA' => '1949-11-08',
+        'ORE' => '00A',
+        'LOCALITA' => 'Nomadelfia',
+    ]);
+
+    $audioId = $connection->table('recording_audio')->insertGetId([
+        'file_name' => '49110800A.mp3',
+        'file_path' => '1950/49110800A.mp3',
+        'file_size_bytes' => 1024,
+        'code' => null,
+        'recording_id' => null,
+    ]);
+
+    $this->artisan('transcripts:sync')->assertSuccessful();
+
+    $audioRow = $connection->table('recording_audio')->where('id', $audioId)->first();
+
+    expect($audioRow)->not->toBeNull();
+    expect($audioRow->code)->toBe('1949110800A');
+    expect($audioRow->recording_id)->toBe($recordingId);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,7 +12,7 @@ use Tests\TestCasePest;
 use function Pest\Laravel\actingAs;
 
 pest()->extends(TestCasePest::class)
-    ->in('Agraria', 'Biblioteca', 'Scuola', 'Popolazione', 'Officina', 'AdminSys', 'Photo', 'Livewire', 'Patente');
+    ->in('Agraria', 'Biblioteca', 'Scuola', 'Popolazione', 'Officina', 'AdminSys', 'Photo', 'Livewire', 'Patente', 'Archive');
 
 function login(?User $user = null): User
 {


### PR DESCRIPTION
Read the mp3 files via the command 

Changes:
- `transcripts:import-mp3` to import the mp3 files from local disk sotres into `AUDIO_PATH` (.env file)
- `transcripts:sync` extended to synch also the mp3 files to the recording