### PR TITLE
fix(transcripts): improve mp3 code extraction regex for audio syncing

### DIFF
--- a/app/Console/Commands/TranscriptsSyncCommand.php
+++ b/app/Console/Commands/TranscriptsSyncCommand.php
@@ -49,9 +49,9 @@ final class TranscriptsSyncCommand extends Command
     {
         $updated = DB::connection('archivio_nomadelfia')->update(<<<'SQL'
             UPDATE recording_audio
-            SET code = CONCAT('19', LEFT(file_name, CHAR_LENGTH(file_name) - 4))
+                        SET code = CONCAT('19', REGEXP_SUBSTR(file_name, '^[0-9]{8}[A-Z0-9]?'))
             WHERE code IS NULL
-              AND file_name REGEXP '^[0-9]{8}[A-Z0-9]?\.mp3$'
+                            AND file_name REGEXP '^[0-9]{8}[A-Z0-9]?( .*)?\.mp3$'
         SQL);
 
         $linked = DB::connection('archivio_nomadelfia')->update(<<<'SQL'

--- a/tests/Archive/Command/TranscriptsSyncCommandTest.php
+++ b/tests/Archive/Command/TranscriptsSyncCommandTest.php
@@ -22,11 +22,31 @@ it('syncs mp3 audio rows to recordings by extracted code', function (): void {
         'recording_id' => null,
     ]);
 
+    $recordingIdWithSuffix = $connection->table('recordings')->insertGetId([
+        'code' => '1976042800',
+        'DATA' => '1976-04-28',
+        'ORE' => '00',
+        'LOCALITA' => 'Nomadelfia',
+    ]);
+
+    $audioIdWithSuffix = $connection->table('recording_audio')->insertGetId([
+        'file_name' => '76042800 Gioacchino.mp3',
+        'file_path' => '1976/76042800 Gioacchino.mp3',
+        'file_size_bytes' => 2048,
+        'code' => null,
+        'recording_id' => null,
+    ]);
+
     $this->artisan('transcripts:sync')->assertSuccessful();
 
     $audioRow = $connection->table('recording_audio')->where('id', $audioId)->first();
+    $audioRowWithSuffix = $connection->table('recording_audio')->where('id', $audioIdWithSuffix)->first();
 
     expect($audioRow)->not->toBeNull();
     expect($audioRow->code)->toBe('1949110800A');
     expect($audioRow->recording_id)->toBe($recordingId);
+
+    expect($audioRowWithSuffix)->not->toBeNull();
+    expect($audioRowWithSuffix->code)->toBe('1976042800');
+    expect($audioRowWithSuffix->recording_id)->toBe($recordingIdWithSuffix);
 });


### PR DESCRIPTION
some mp3 file has also text in the file name. 
For example, given `64040500A da rivedere.mp3` => `64040500A`