### PR TITLE
fix(transcripts): add truncate method to clear sync columns and improve audio code

### DIFF
--- a/app/Console/Commands/TranscriptsSyncCommand.php
+++ b/app/Console/Commands/TranscriptsSyncCommand.php
@@ -18,6 +18,7 @@ final class TranscriptsSyncCommand extends Command
 
     public function handle(): int
     {
+        $this->truncateCodesAndRecordingLinks();
         $this->buildRecordingCode();
         $this->buildRecordingCodeFromDocx();
         $this->buildRecordingCodeFromAudio();
@@ -25,6 +26,29 @@ final class TranscriptsSyncCommand extends Command
         $this->syncAudioFiles();
 
         return self::SUCCESS;
+    }
+
+    private function truncateCodesAndRecordingLinks(): void
+    {
+        $connection = DB::connection('archivio_nomadelfia');
+
+        $updatedRecordings = $connection->table('recordings')->update([
+            'code' => null,
+        ]);
+
+        $updatedTranscripts = $connection->table('recording_transcripts')->update([
+            'code' => null,
+            'recording_id' => null,
+        ]);
+
+        $updatedAudio = $connection->table('recording_audio')->update([
+            'code' => null,
+            'recording_id' => null,
+        ]);
+
+        $this->info(
+            "Cleared sync columns. recordings: {$updatedRecordings}, recording_transcripts: {$updatedTranscripts}, recording_audio: {$updatedAudio}"
+        );
     }
 
     private function buildRecordingCode(): void
@@ -46,7 +70,7 @@ final class TranscriptsSyncCommand extends Command
                 $code = TranscriptCode::fromString($rawCode);
                 $updates[] = [$recording->id, $code->toString()];
             } catch (InvalidArgumentException $e) {
-                $this->warn("Skipped recording {$recording->id}: {$e->getMessage()}");
+                $this->warn("Skipped recording {$rawCode}: {$e->getMessage()}");
             }
         }
 
@@ -100,7 +124,7 @@ final class TranscriptsSyncCommand extends Command
                     $updates[] = [$transcript->id, $normalizedCode];
                 }
             } catch (InvalidArgumentException $e) {
-                $this->warn("Skipped transcript {$transcript->id}: {$e->getMessage()}");
+                $this->warn("Skipped transcript {$extractedCode}: {$e->getMessage()}");
             }
         }
 
@@ -138,23 +162,23 @@ final class TranscriptsSyncCommand extends Command
         $updates = [];
 
         foreach ($audioFiles as $audio) {
-            $fileNameWithoutExt = (string) preg_replace('/\.mp3$/i', '', (string) $audio->file_name);
+            $rawCode = $this->extractAudioCodeFromFileName((string) $audio->file_name);
 
-            if (empty($fileNameWithoutExt)) {
+            if (empty($rawCode)) {
                 $this->warn("Could not extract code from file name in audio {$audio->id}");
 
                 continue;
             }
 
             try {
-                $code = TranscriptCode::fromString($fileNameWithoutExt);
+                $code = TranscriptCode::fromString($rawCode);
                 $normalizedCode = $code->toString();
 
                 if ($audio->code !== $normalizedCode) {
                     $updates[] = [$audio->id, $normalizedCode];
                 }
             } catch (InvalidArgumentException $e) {
-                $this->warn("Skipped audio {$audio->id}: {$e->getMessage()}");
+                $this->warn("Skipped audio {$rawCode}: {$e->getMessage()}");
             }
         }
 
@@ -179,6 +203,13 @@ final class TranscriptsSyncCommand extends Command
         });
 
         $this->info("Built recording code from audio. Rows affected: {$count}");
+    }
+
+    private function extractAudioCodeFromFileName(string $fileName): string
+    {
+        $fileName = Str::beforeLast($fileName, '.'); // remove extension
+
+        return Str::of($fileName)->squish()->before(' ')->toString();
     }
 
     private function syncDocxFiles(): void

--- a/tests/Archive/Command/TranscriptsSyncCommandTest.php
+++ b/tests/Archive/Command/TranscriptsSyncCommandTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Console\Commands\TranscriptsSyncCommand;
 use Illuminate\Support\Facades\DB;
 
 it('syncs mp3 audio rows to recordings by extracted code', function (): void {
@@ -12,7 +13,6 @@ it('syncs mp3 audio rows to recordings by extracted code', function (): void {
             'DATA' => '1949-11-08',
             'ORE' => '12',
         ],
-
     );
 
     $audioId = $connection->table('recording_audio')->insertGetId([
@@ -43,7 +43,6 @@ it('syncs mp3 audio rows to recordings by extracted code', function (): void {
     expect($transcriptRecordingId)
         ->not->toBeNull()
         ->toBe($recordingId);
-
 });
 
 it('syncs rows when ORE is null and maps to 0A code', function (): void {
@@ -121,3 +120,18 @@ it('syncs rows when ORE is already 0A', function (): void {
         ->not->toBeNull()
         ->toBe($recordingId);
 });
+
+it('extracts audio code from mp3 file name', function (string $fileName, string $expectedCode): void {
+    $command = new TranscriptsSyncCommand();
+
+    $method = new ReflectionMethod(TranscriptsSyncCommand::class, 'extractAudioCodeFromFileName');
+    $method->setAccessible(true);
+
+    expect($method->invoke($command, $fileName))->toBe($expectedCode);
+})->with([
+    'with standard file name' => ['49110812.mp3', '49110812'],
+    'with 0A suffix hour' => ['4911080A.MP3', '4911080A'],
+    'with non-mp3 extension' => ['4911080A.wav', '4911080A'],
+    'with additional text in file name' => ['4911080A MY AUDIO.mp3', '4911080A'],
+    'with spaces' => ['   4911080B .mp3', '4911080B'],
+])->only();


### PR DESCRIPTION
Fix the error of mp3 ` Invalid hour segment: '00A a text after the hour'`  by splitting and removing the text after the first occurences 